### PR TITLE
docs(009-roadmap-generator): make Feature 009 canonical roadmap lifecycle owner

### DIFF
--- a/specs/009-roadmap-generator/contracts/rest-api.md
+++ b/specs/009-roadmap-generator/contracts/rest-api.md
@@ -1,8 +1,8 @@
 # REST API Contract: Roadmap Module
 
 **Feature**: `009-roadmap-generator`
-**Date**: 2026-03-11
-**Base path**: `/api/roadmap`
+**Date**: 2026-03-14
+**Base path**: `/api`
 **Authentication**: All endpoints require a valid JWT in `Authorization: Bearer <token>`. The middleware attaches `req.user.userId` (ObjectId) to every request.
 
 ---
@@ -30,17 +30,21 @@ Content-Type: application/json
 | HTTP | `code` | Meaning |
 |---|---|---|
 | 401 | `UNAUTHORIZED` | Missing or invalid JWT |
-| 404 | `ROADMAP_NOT_FOUND` | No roadmap document exists for this user |
-| 404 | `PREVIEW_NOT_FOUND` | No in-memory preview is pending for this user |
-| 409 | `GENERATION_IN_PROGRESS` | A generation is already running for this user |
-| 409 | `NO_FAILED_ROADMAP` | Retry attempted but no `status: failed` roadmap exists for this user |
+| 404 | `ROADMAP_NOT_FOUND` | Roadmap does not exist (or does not belong to authenticated user) |
+| 409 | `CONFLICT` | Conflict with current lifecycle state (generation in progress / primary switch race / duplicate transition) |
+| 422 | `PREREQUISITE_VIOLATION` | Submitted roadmap nodes violate prerequisite constraints |
+| 422 | `ALL_COMPLETED` | All submitted nodes were filtered out because they are already completed |
 | 500 | `INTERNAL_ERROR` | Unexpected server error |
 
 ---
 
-## GET /api/roadmap
+## GET /api/primary-roadmap
 
-Retrieve the authenticated student's active roadmap document from the `roadmaps` collection. Returns the full document (including all nodes and metadata). Used by Feature 004 (Skill Tree) to render the roadmap and to determine whether a retry affordance is appropriate (`status: failed`).
+Retrieve the authenticated student's current primary roadmap document.
+
+### Compatibility note
+
+`GET /api/roadmap` is deprecated and maintained only as a compatibility alias to this endpoint during migration.
 
 ### Request
 
@@ -70,7 +74,9 @@ No body.
     }
   ],
   "createdAt": "2026-03-11T08:00:00.000Z",
-  "acceptedAt": "2026-03-11T08:05:00.000Z"
+  "isPrimary": true,
+  "acceptedAt": "2026-03-11T08:05:00.000Z",
+  "updatedAt": "2026-03-14T06:05:00.000Z"
 }
 ```
 
@@ -85,21 +91,144 @@ No body.
 }
 ```
 
-**Note on `status: failed`**: When the roadmap exists but `status` is `failed`, the endpoint still returns 200 with the document — `errorMessage` will be non-null and `acceptedAt` will be `null`. Feature 004 uses this to determine whether to show a retry affordance (FR-029).
-
 ---
 
-## POST /api/roadmap/preview/accept
+## GET /api/roadmaps
 
-Accept the pending in-memory roadmap preview. Commits the preview as the student's active Roadmap document (status `completed`), replacing any previously stored document. Clears the in-memory preview after commit. If the generation was triggered by `repersonalization`, also clears `repersonalizationPending` on the `StudentProfile` (FR-031).
+List roadmap documents for the authenticated user.
 
-### Request
+### Query parameters
 
-No body. The preview is identified by `req.user.userId`.
+- `status` (optional): `completed` | `failed`
+- `page` (optional, default `1`)
+- `limit` (optional, default `20`, max `100`)
 
 ### Response — 200 OK
 
-Returns the newly committed Roadmap document.
+```json
+{
+  "items": [
+    {
+      "_id": "64a1b2c3d4e5f6a7b8c9d0e1",
+      "userId": "64a1b2c3d4e5f6a7b8c9d0e2",
+      "studentProfileId": "64a1b2c3d4e5f6a7b8c9d0e3",
+      "personalisationLevel": "full",
+      "status": "completed",
+      "isPrimary": true,
+      "errorMessage": null,
+      "updatedAt": "2026-03-14T06:05:00.000Z",
+      "acceptedAt": "2026-03-11T08:05:00.000Z"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "limit": 20,
+    "total": 1
+  }
+}
+```
+
+---
+
+## GET /api/roadmaps/:roadmapId
+
+Get roadmap detail by ID (auth-scoped to requester).
+
+### Response — 200 OK
+
+Returns the full roadmap document.
+
+### Response — 404 Not Found
+
+```json
+{
+  "error": {
+    "code": "ROADMAP_NOT_FOUND",
+    "message": "Roadmap not found."
+  }
+}
+```
+
+---
+
+## PATCH /api/roadmaps/:roadmapId/primary
+
+Set a specific roadmap as primary for the authenticated user. The previous primary is demoted atomically.
+
+### Request
+
+No body.
+
+### Response — 200 OK
+
+```json
+{
+  "message": "Primary roadmap updated successfully.",
+  "roadmapId": "64a1b2c3d4e5f6a7b8c9d0e1",
+  "isPrimary": true
+}
+```
+
+### Response — 404 Not Found
+
+```json
+{
+  "error": {
+    "code": "ROADMAP_NOT_FOUND",
+    "message": "Roadmap not found."
+  }
+}
+```
+
+### Response — 409 Conflict
+
+```json
+{
+  "error": {
+    "code": "CONFLICT",
+    "message": "Primary roadmap update conflicted with another in-flight operation. Please retry."
+  }
+}
+```
+
+---
+
+## POST /api/roadmaps/accept
+
+Fork-consumable acceptance endpoint. The caller submits full roadmap nodes payload. Server performs canonical acceptance pipeline:
+
+1. Filter completed courses,
+2. Validate prerequisite constraints/topological order,
+3. Commit a roadmap document and apply primary policy.
+
+This endpoint does not depend on old preview-accept lookup.
+
+### Request
+
+```json
+{
+  "studentProfileId": "64a1b2c3d4e5f6a7b8c9d0e3",
+  "personalisationLevel": "full",
+  "isPrimary": true,
+  "nodes": [
+    {
+      "courseCode": "INT2204",
+      "courseName": "Object-Oriented Programming",
+      "credits": 3,
+      "suggestedSemester": 2,
+      "gainedSkills": ["OOP principles", "Java fundamentals"],
+      "supportingSkills": ["SOLID principles"],
+      "reason": "Foundation for software engineering.",
+      "careerRelevanceNote": "Useful for backend development at product companies.",
+      "resources": []
+    }
+  ]
+}
+```
+
+### Response — 200 OK
+
+Returns the committed roadmap document.
 
 ```json
 {
@@ -108,49 +237,44 @@ Returns the newly committed Roadmap document.
   "studentProfileId": "64a1b2c3d4e5f6a7b8c9d0e3",
   "personalisationLevel": "full",
   "status": "completed",
+  "isPrimary": true,
   "errorMessage": null,
-  "nodes": [ /* … same shape as GET /api/roadmap response … */ ],
+  "nodes": [ /* … same shape as primary roadmap response … */ ],
   "createdAt": "2026-03-11T08:00:00.000Z",
-  "acceptedAt": "2026-03-11T08:05:12.000Z"
+  "acceptedAt": "2026-03-11T08:05:12.000Z",
+  "updatedAt": "2026-03-14T06:05:12.000Z"
 }
 ```
 
-### Response — 404 Not Found (no pending preview)
+### Response — 422 Unprocessable Entity (`ALL_COMPLETED`)
 
 ```json
 {
   "error": {
-    "code": "PREVIEW_NOT_FOUND",
-    "message": "No pending roadmap preview found. The preview may have expired due to a server restart."
+    "code": "ALL_COMPLETED",
+    "message": "All submitted roadmap nodes are already completed by this student."
   }
 }
 ```
 
----
-
-## POST /api/roadmap/preview/reject
-
-Reject and discard the pending in-memory roadmap preview. The existing active roadmap (if any) remains unchanged. If the generation was triggered by `repersonalization`, also clears `repersonalizationPending` on the `StudentProfile` (FR-031, FR-038). For initial generation rejections, the student is left without an active roadmap — the retry mechanism remains available (FR-037).
-
-### Request
-
-No body. The preview is identified by `req.user.userId`.
-
-### Response — 200 OK
-
-```json
-{
-  "message": "Preview rejected. Your existing roadmap is unchanged."
-}
-```
-
-### Response — 404 Not Found (no pending preview)
+### Response — 422 Unprocessable Entity (`PREREQUISITE_VIOLATION`)
 
 ```json
 {
   "error": {
-    "code": "PREVIEW_NOT_FOUND",
-    "message": "No pending roadmap preview found."
+    "code": "PREREQUISITE_VIOLATION",
+    "message": "Ordering violation: INT3101 appears before prerequisite INT2204."
+  }
+}
+```
+
+### Response — 409 Conflict
+
+```json
+{
+  "error": {
+    "code": "CONFLICT",
+    "message": "Roadmap acceptance conflicted with an in-flight lifecycle operation. Please retry."
   }
 }
 ```
@@ -180,7 +304,7 @@ No body.
 ```json
 {
   "error": {
-    "code": "GENERATION_IN_PROGRESS",
+    "code": "CONFLICT",
     "message": "A roadmap generation is already running for this user. Please wait for it to complete."
   }
 }
@@ -191,7 +315,7 @@ No body.
 ```json
 {
   "error": {
-    "code": "NO_FAILED_ROADMAP",
+    "code": "CONFLICT",
     "message": "No failed roadmap generation found. Retry is only available after a generation failure."
   }
 }
@@ -207,4 +331,10 @@ Generation is triggered internally by two system events (FR-033):
 
 2. **Repersonalization** — emitted by Feature 005's account settings handler after setting `repersonalizationPending: true` on the `StudentProfile`. The roadmap module exports `triggerGeneration(userId, studentProfileId, 'repersonalization')` called via the service layer.
 
-Neither trigger is exposed as a REST endpoint. The `GENERATION_IN_PROGRESS` error is handled internally — if generation is already running when either trigger fires, the call is silently dropped (the in-progress generation will complete and notify the student).
+Neither trigger is exposed as a REST endpoint. Internal generation conflicts map to canonical `CONFLICT` semantics — if generation is already running when either trigger fires, the call is silently dropped (the in-progress generation will complete and notify the student).
+
+---
+
+## Lifecycle Ownership Rule
+
+Feature 009 is the canonical owner of roadmap transitions and persistence semantics. Other features must consume roadmap state through the contracts above and must not write `roadmaps` directly.

--- a/specs/009-roadmap-generator/data-model.md
+++ b/specs/009-roadmap-generator/data-model.md
@@ -1,7 +1,7 @@
 # Data Model: AI-Powered Personalised Roadmap Generator
 
 **Feature**: `009-roadmap-generator`
-**Date**: 2026-03-11
+**Date**: 2026-03-14
 **Research dependency**: [research.md](research.md) (R-001, R-003, R-004)
 
 ---
@@ -10,34 +10,39 @@
 
 **MongoDB collection**: `roadmaps`
 
-**Purpose**: Single document per authenticated student holding their accepted, active learning roadmap — or a failure record awaiting retry. Only an explicitly accepted preview may be committed here. One document per user at all times (enforced by unique index on `userId`).
+**Purpose**: Canonical roadmap store owned by Feature 009. A user may have multiple roadmap documents (history/variants), but exactly one roadmap can be primary at any time.
 
 ### Schema
 
 | Field | Type | Required | Default | Constraints | Notes |
 |---|---|---|---|---|---|
 | `_id` | ObjectId | auto | — | — | MongoDB primary key |
-| `userId` | ObjectId | yes | — | **Unique index**; ref: `users` | Foreign key to authenticated user (Feature 005) |
+| `userId` | ObjectId | yes | — | Indexed; ref: `users` | Foreign key to authenticated user (Feature 005) |
+| `isPrimary` | Boolean | yes | `false` | Partial unique index scope (`isPrimary: true`) | Exactly one primary roadmap per user |
 | `studentProfileId` | ObjectId | yes | — | ref: `student_profiles` | The profile snapshot that drove this generation (Feature 001) |
 | `personalisationLevel` | String | yes | — | Enum: `full` \| `low` | `low` when no career goal provided (FR-020) |
 | `status` | String | yes | — | Enum: `completed` \| `failed` | `completed` = accepted and active; `failed` = generation failure awaiting retry (FR-024) |
 | `errorMessage` | String \| null | no | `null` | Set on failure; `null` on completed | Human-readable generation error stored for internal debugging (FR-028) |
 | `nodes` | RoadmapNode[] | yes | `[]` | Ordered array; see embedded doc below | Empty array is valid (e.g., all courses completed) |
 | `createdAt` | Date | auto | `Date.now()` | Set on first insert (`$setOnInsert`) | |
-| `acceptedAt` | Date \| null | no | `null` | Set on acceptance; never overwritten | `null` on `failed` documents |
+| `acceptedAt` | Date \| null | no | `null` | Set on acceptance | `null` on `failed` documents |
+| `updatedAt` | Date | auto | `Date.now()` | Indexed via list index | Timeline/list ordering |
 
 ### Indexes
 
 | Name | Fields | Type | Enforces |
 |---|---|---|---|
 | `_id` (default) | `_id` | Unique | MongoDB default |
-| `userId_unique` | `{ userId: 1 }` | **Unique** | One roadmap document per student (FR-023); fast lookup by auth token |
+| `primary_per_user_unique` | `{ userId: 1, isPrimary: 1 }` with `partialFilterExpression: { isPrimary: true }` | **Unique (partial)** | At most one primary roadmap per user |
+| `roadmap_list_by_user_status_updatedAt` | `{ userId: 1, status: 1, updatedAt: -1 }` | Non-unique | Fast listing by user with optional status filter and recency sort |
+| `roadmap_detail_by_user_id` | `{ userId: 1, _id: 1 }` | Non-unique | Auth-scoped detail lookup |
 
 ### Validation rules applied at service layer
 
 - `personalisationLevel` is derived from the `StudentProfile` before the Gemini call — it is NOT set from user input.
-- `status` transitions are controlled exclusively by the generation lifecycle and acceptance services — no direct client-provided status is accepted.
+- `status` transitions are controlled exclusively by Feature 009 generation/acceptance services — no direct client-provided status is accepted.
 - `errorMessage` is set only on generation failure (never on acceptance); it is cleared (set to `null`) when the document is updated to `completed` via `upsertCompleted`.
+- `isPrimary` assignment is controlled only by Feature 009 primary-switch rules (`PATCH /api/roadmaps/:roadmapId/primary`) and acceptance commit policy.
 
 ---
 
@@ -65,7 +70,7 @@
 
 ---
 
-## State Machine: Roadmap Document
+## State Machine: Roadmap Document (Canonical Rules)
 
 ```text
                     ┌──────────────────────────────────────────┐
@@ -74,20 +79,21 @@
 
   [non-existent]
        │
-       │  generation completes → student accepts preview
+       │  accepted payload commit (filter→validate→commit)
        ▼
-  [completed]  { status: 'completed', nodes: [...], acceptedAt: Date, errorMessage: null }
+  [completed, isPrimary=true|false]
        │
-       ├─── re-generation completes → student accepts new preview
-       │    ──────────────────────────────────────────────────────────────────────▶ [completed]  (document replaced in-place)
+       ├── generation fails
+       │   ▼
+       │ [failed, isPrimary unchanged]
        │
-       └─── generation fails (Gemini error / topo violation / parse error / restart)
-            ▼
-       [failed]  { status: 'failed', errorMessage: string, nodes: [...prev or []] }
-            │
-            │  student triggers /api/roadmap/retry → generation completes → student accepts
-            ▼
-       [completed]  (document replaced in-place)
+       ├── PATCH /api/roadmaps/:roadmapId/primary
+       │   ▼
+       │ [completed, isPrimary=true] + previous primary -> isPrimary=false
+       │
+       └── new accepted commit
+           ▼
+         [completed, new version document]
 ```
 
 **Initial failure path** (no prior accepted roadmap exists):
@@ -96,7 +102,7 @@
        │  initial generation fails
        ▼
   [failed]  (created on first failure)
-       │  retry succeeds + student accepts
+       │  retry succeeds + accepted payload commit
        ▼
   [completed]
 ```
@@ -105,20 +111,32 @@
 
 | From | To | Guard | Failure response |
 |---|---|---|---|
-| non-existent | completed | `findOneAndUpdate({ userId }, ..., { upsert: true })` on acceptance | — |
-| non-existent | failed | `findOneAndUpdate({ userId }, ..., { upsert: true })` on generation failure | — |
-| completed | completed | Student accepts new preview; `upsertCompleted` replaces document in-place | — |
-| completed | failed | Re-generation fails; `upsertFailed` updates `status` and `errorMessage` | Previous `nodes` retained for display; only `status` and `errorMessage` change |
-| failed | completed | Student triggers retry → generation succeeds → student accepts | 409 if generation already in-progress |
-| any | any | No direct client-provided status update is permitted | Controller returns 400 if `status` is in request body |
+| non-existent | completed | Acceptance payload passes completed-filter + prerequisite validation | `ALL_COMPLETED` or `PREREQUISITE_VIOLATION` |
+| any | failed | Generation failure in lifecycle | Stored as failed with error message |
+| failed | completed | Retry + acceptance payload passes validation | `CONFLICT` if generation already in progress |
+| completed | completed | New accepted roadmap committed as new document version | `CONFLICT` on primary race |
+| completed/failed | primary switched | `PATCH /api/roadmaps/:roadmapId/primary` transactional demote/promote | `ROADMAP_NOT_FOUND` / `CONFLICT` |
+| any | any | No direct client-provided status transition allowed | 400 |
 
-**Re-generation failure note**: When a re-generation fails while the student has an existing `completed` roadmap, the `status` is updated to `failed` and `errorMessage` is set, but the `nodes` array from the previous accepted generation is preserved. Feature 004 can continue rendering the previous course sequence while showing the "generation failed — retry available" state. On retry success and acceptance, the document is fully replaced with the new `nodes`.
+**Re-generation failure note**: On re-generation failure, Feature 009 records a failed roadmap state per canonical lifecycle rules. Existing completed roadmap versions remain queryable; primary selection is unaffected unless explicitly switched.
 
 ---
 
-## In-Memory Entity: RoadmapPreview Store
+## Primary Selection Invariant
 
-**Not a MongoDB collection** — lives only in the Node.js process heap. Lost on Render restart (this is the designed behaviour per FR-034). The generation lifecycle stores a preview here after a successful Gemini call; the acceptance/rejection endpoints look it up and clear it.
+For each `userId`, the system invariant is:
+
+$$
+\sum\_{r \in \text{Roadmaps}(userId)} [r.isPrimary = true] = 1
+$$
+
+Feature 009 enforces this invariant using a partial unique index and transaction-safe demote/promote logic.
+
+---
+
+## In-Memory Entity: RoadmapPreview Store (Transient)
+
+**Not a MongoDB collection** — lives only in the Node.js process heap. Lost on Render restart. The generation lifecycle may store preview payload for notification/review UX. Acceptance commit no longer depends on this store as source of truth.
 
 | Property | Value |
 |---|---|
@@ -126,7 +144,7 @@
 | Key | `userId.toString()` |
 | Value | `{ nodes, personalisationLevel, triggerReason, studentProfileId }` |
 | Max entries | One per user with a pending review (typically low) |
-| Cleanup | `clearPendingPreview(userId)` called on accept, reject, or generation failure |
+| Cleanup | `clearPendingPreview(userId)` called on superseded preview, explicit discard, or generation failure |
 | Restart handling | `SIGTERM` handler iterates all keys, calls `upsertFailed`, clears all entries |
 
 **See**: [research.md R-004](research.md) for implementation pattern and SIGTERM handler.
@@ -139,7 +157,7 @@
 
 **MongoDB collection**: `student_profiles`
 **Owned by**: Feature 001 (Profile Onboarding)
-**Access from this feature**: `findOne({ _id: studentProfileId })` to retrieve profile for generation input. `findOneAndUpdate({ userId }, { $set: { repersonalizationPending: false } })` to clear the flag after re-generation preview accept/reject (FR-031). No other writes.
+**Access from this feature**: `findOne({ _id: studentProfileId })` to retrieve profile for generation input. `findOneAndUpdate({ userId }, { $set: { repersonalizationPending: false } })` to clear the flag after canonical acceptance/discard handling (FR-031). No other writes.
 
 | Field | Type | Notes |
 |---|---|---|

--- a/specs/009-roadmap-generator/plan.md
+++ b/specs/009-roadmap-generator/plan.md
@@ -1,11 +1,21 @@
 # Implementation Plan: AI-Powered Personalised Roadmap Generator
 
-**Branch**: `009-roadmap-generator` | **Date**: 2026-03-11 | **Spec**: [spec.md](spec.md)
+**Branch**: `009-roadmap-generator` | **Date**: 2026-03-14 | **Spec**: [spec.md](spec.md)
 **Input**: Feature specification from `/specs/009-roadmap-generator/spec.md`
 
 ## Summary
 
-Build the async AI roadmap generation backend for UETCompass. When a student submits their onboarding profile (Feature 001) or updates their career goal (Feature 005), the system asynchronously calls Gemini 1.5 Flash with the student's `StudentProfile` and the full `CourseUnit` DAG for their major, instructing the AI to select career-relevant courses and return them in topological order with per-node skill enrichment. The AI response is validated against a `responseSchema` and then subject to a system-level topological sort check (DFS, O(V+E)). On success, a `RoadmapPreview` is held in-memory and the student is notified via the existing SSE infrastructure (Feature 005). The roadmap is committed to the `roadmaps` MongoDB collection only after the student explicitly accepts the preview. One `roadmaps` document exists per student (unique on `userId`); valid persisted statuses are `completed` and `failed`. A retry mechanism is available for failed generations without requiring profile resubmission. Re-generation uses the existing accepted roadmap as additional AI context alongside the updated profile.
+Feature 009 is the canonical owner of roadmap lifecycle. Other features can only consume roadmap data through 009 API/service contracts and must not mutate roadmap state directly.
+
+The backend keeps async AI generation (Gemini + topological validation) but upgrades the persistence model to multi-roadmap per user with exactly one primary roadmap:
+
+- add `isPrimary` on roadmap documents,
+- enforce one-primary-per-user with partial unique index,
+- support timeline/history listing by `userId`, `status`, and `updatedAt`.
+
+Primary retrieval moves from `GET /api/roadmap` to `GET /api/primary-roadmap` (with compatibility note). New list/detail/primary-switch endpoints are introduced under `/api/roadmaps`.
+
+Acceptance is refactored to a fork-consumable flow that receives full roadmap nodes in request payload (no old preview-accept lookup). Required pipeline: filter completed → prerequisite validation → commit.
 
 ## Technical Context
 
@@ -14,23 +24,23 @@ Build the async AI roadmap generation backend for UETCompass. When a student sub
 - Backend: `express.js`, `mongoose 8`, `@google/generative-ai`
 - Notifications: `notification.service.js` + `notification.sse.js`
 
-**Storage**: MongoDB Atlas free tier — `roadmaps` collection (new; unique index on `userId`); reads `student_profiles` (owned by Feature 001) and `course_units` (owned by Feature 002) via service-layer calls; in-memory `Map<userId, PreviewPayload>` for pre-acceptance previews (not persisted to any collection)
+**Storage**: MongoDB Atlas free tier — `roadmaps` collection (multi documents per user) with partial unique primary index and list-query index; reads `student_profiles` (owned by Feature 001) and `course_units` (owned by Feature 002) via service-layer calls; in-memory preview remains transient for generation review but is not the source of truth for acceptance commit
 **Testing**: Jest 29 — unit tests only; `@google/generative-ai`, Mongoose, and `notification.service.js` all mocked via `jest.fn()` / `jest.mock()`
 **Target Platform**: Backend → Render (Node.js web service, free tier, single instance); Frontend → Vercel (React SPA)
 **Project Type**: Web application — React SPA + Node.js/Express REST API (modular monolith)
-**Performance Goals**: Generation result delivered asynchronously via SSE — no synchronous response latency requirement for the generation itself. Preview accept/reject endpoints < 300ms p95 (single in-memory Map lookup + one MongoDB upsert)
+**Performance Goals**: Generation result delivered asynchronously via SSE — no synchronous response latency requirement for generation itself. `GET /api/primary-roadmap`, `GET /api/roadmaps`, `GET /api/roadmaps/:roadmapId`, and `PATCH /api/roadmaps/:roadmapId/primary` < 300ms p95. Acceptance commit endpoint < 500ms p95 including prerequisite validation.
 **Constraints**: No Redis — in-process async only; concurrency guard = module-level `Set<string>` of active `userId` strings; preview held in-memory on worker only (not persisted; lost on restart); no cross-module direct imports — service-layer calls only
-**Scale/Scope**: UET-VNU students only; one roadmap per user; single Render instance; hundreds to low-thousands of concurrent users
+**Scale/Scope**: UET-VNU students only; multi-roadmap per user with exactly one primary roadmap; single Render instance; hundreds to low-thousands of concurrent users
 
 ## Constitution Check
 
 *Pre-design gate — re-checked after Phase 1 design: all items pass.*
 
-- [x] **Modular Monolithic**: All roadmap logic is isolated in `backend/src/modules/roadmap/`. No direct cross-module imports — reads `student_profiles` and `course_units` via service-layer calls only. Notifications delivered through the existing `notification.service.js` shared module (Feature 005). No microservice split introduced.
+- [x] **Modular Monolithic**: All roadmap logic is isolated in `backend/src/modules/roadmap/`. Feature 009 is the only owner of lifecycle transitions. No direct cross-module imports — reads `student_profiles` and `course_units` via service-layer calls only. Notifications delivered through the existing `notification.service.js` shared module (Feature 005). No microservice split introduced.
 - [x] **UET-First**: No generalisation — the implementation is hardcoded for UET's `CourseUnit` DAG structure and `StudentProfile` schema. No abstraction for other universities.
 - [x] **Privacy by Minimalism**: No grades, GPA, or transcript data stored. The `roadmaps` collection holds only course codes, AI-generated skill/reason text, and timestamps. No student credentials involved. The `completedCourseIds` used as prerequisite anchors are already stored in Feature 001's `student_profiles` collection — no new personal data is collected by this feature.
-- [x] **AI-Assisted, Human-Controlled**: Gemini output is validated at two levels before storage — `responseSchema` enforces structure server-side, and the system performs an independent topological sort check (DFS). The student explicitly accepts or rejects every roadmap preview; the AI never commits the roadmap directly.
-- [x] **Test What Matters**: Mandatory unit tests for: generation lifecycle (Gemini output parsing, topological sort validation, failure path), roadmap acceptance service (accept/reject, `repersonalizationPending` clear), and roadmap service (upsert, single-document invariant). All external deps mocked.
+- [x] **AI-Assisted, Human-Controlled**: Gemini output is validated at two levels before storage — `responseSchema` enforces structure server-side, and the system performs independent prerequisite/topological checks. Commits happen only through explicit acceptance API.
+- [x] **Test What Matters**: Mandatory unit tests for: generation lifecycle, acceptance pipeline (filter completed → prerequisite validation → commit), primary-switch rule (exactly one primary), and roadmap list/detail retrieval. All external deps mocked.
 
 ## Project Structure
 
@@ -55,22 +65,34 @@ backend/
 ├── src/
 │   └── modules/
 │       └── roadmap/
-│           ├── roadmap.model.js                  # roadmaps Mongoose schema + model
-│           ├── roadmap.service.js                # getByUser, upsertFailed, upsertCompleted
+│           ├── roadmap.model.js                  # roadmaps Mongoose schema + indexes (partial unique primary)
+│           ├── roadmap.service.js                # getPrimaryByUser, listByUser, getByIdForUser, upsertFailed, commitAccepted
 │           ├── generation.service.js             # generation lifecycle, Gemini call, topo validation, concurrency guard
 │           ├── roadmap.preview.store.js          # in-memory Map<userId, PreviewPayload> + SIGTERM handler
-│           ├── roadmapAcceptance.service.js      # accept preview, reject preview, clear repersonalizationPending
+│           ├── roadmapValidation.service.js      # completed-course filter + prerequisite validation
+│           ├── roadmapAcceptance.service.js      # fork-consumable acceptance with full nodes payload
 │           ├── roadmap.controller.js             # Express handlers (thin — delegate to services)
-│           └── roadmap.routes.js                 # /api/roadmap/* routes + auth middleware
+│           └── roadmap.routes.js                 # /api/primary-roadmap + /api/roadmaps/* routes + auth middleware
 └── tests/
     └── unit/
         └── roadmap/
             ├── generation.service.test.js        # Gemini output parsing, topo sort validation, failure path, concurrency guard
-            ├── roadmapAcceptance.service.test.js # accept/reject, repersonalizationPending cleared, no-preview 404
-            └── roadmap.service.test.js           # upsertFailed, upsertCompleted, single-document invariant
+            ├── roadmapAcceptance.service.test.js # full payload accept flow + prerequisite guards
+            ├── roadmapPrimary.service.test.js    # one-primary-per-user invariant
+            └── roadmap.service.test.js           # list/detail/primary retrieval + commit behavior
 ```
 
-**Structure Decision**: Option 2 — Web application. Modular monolith backend; all roadmap logic isolated in `modules/roadmap/`. Feature 001's `student_profiles` and Feature 002's `course_units` are read-only from this module via service-layer calls. Feature 005's `notifications` module is used for SSE delivery. No frontend source code is in scope — rendering is owned by Feature 004.
+**Structure Decision**: Option 2 — Web application. Modular monolith backend; all roadmap logic isolated in `modules/roadmap/` and owned by Feature 009 as canonical lifecycle authority. Feature 001's `student_profiles` and Feature 002's `course_units` are read-only from this module via service-layer calls. Feature 005's `notifications` module is used for SSE delivery. No frontend source code is in scope — rendering is owned by Feature 004.
+
+## Lifecycle Ownership Rule
+
+Feature 009 is the single authority that defines:
+
+- allowable roadmap statuses and transitions,
+- primary roadmap assignment/switch semantics,
+- acceptance validation gates and conflict behavior.
+
+No other feature may define or bypass these transition rules.
 
 ## Complexity Tracking
 

--- a/specs/009-roadmap-generator/research.md
+++ b/specs/009-roadmap-generator/research.md
@@ -1,8 +1,8 @@
 # Research: AI-Powered Personalised Roadmap Generator
 
 **Feature**: `009-roadmap-generator`
-**Date**: 2026-03-11
-**Status**: Complete — all unknowns resolved
+**Date**: 2026-03-14
+**Status**: Refined — canonical lifecycle ownership + multi-roadmap model applied
 
 ---
 
@@ -163,7 +163,7 @@ If `validateTopologicalOrder()` throws, `generation.service.js` catches the erro
 
 ## R-003: In-Process Async Generation + Concurrency Guard
 
-**Decision**: Fire-and-forget `async` function from the generation trigger (no `await` at the call site). Concurrency guard = module-level `Set<string>` of active `userId` strings in `generation.service.js`. Add `userId` on generation start; delete in the `finally` block on completion or failure. On new trigger, check `Set` membership before starting — reject with `GENERATION_IN_PROGRESS` if found.
+**Decision**: Fire-and-forget `async` function from the generation trigger (no `await` at the call site). Concurrency guard = module-level `Set<string>` of active `userId` strings in `generation.service.js`. Add `userId` on generation start; delete in the `finally` block on completion or failure. On new trigger, check `Set` membership before starting — reject with canonical `CONFLICT` semantics if found.
 
 **Rationale**: No Redis, no BullMQ — Render free-tier is a single instance with no external queue service (established in Feature 001). An in-memory `Set` is the correct single-instance concurrency guard. The fire-and-forget pattern keeps the HTTP trigger response immediate (202 Accepted) while generation runs in the background.
 
@@ -174,7 +174,7 @@ const activeGenerations = new Set(); // module-level; one entry per userId curre
 
 async function triggerGeneration(userId, studentProfileId, triggerReason) {
   if (activeGenerations.has(userId.toString())) {
-    throw new Error('GENERATION_IN_PROGRESS');
+    throw new Error('CONFLICT');
   }
 
   // Fire and forget — caller returns immediately
@@ -226,11 +226,11 @@ Worker restart recovery: the `finally` block always runs on normal termination. 
 
 ---
 
-## R-004: In-Memory Preview Storage
+## R-004: In-Memory Preview Storage (Transient UX Only)
 
-**Decision**: Module-level `Map<string, PreviewPayload>` in a dedicated `roadmap.preview.store.js` file, mapping `userId.toString()` to the full preview payload. The accept endpoint reads and clears the preview; the reject endpoint clears it without committing. Preview does not survive a worker restart (per FR-034).
+**Decision**: Keep module-level `Map<string, PreviewPayload>` in `roadmap.preview.store.js`, keyed by `userId.toString()`, but treat it as transient UX cache only. Acceptance commit no longer reads from this store as source of truth; fork-consumable acceptance receives full nodes payload directly.
 
-**Rationale**: No `roadmap_previews` MongoDB collection — the spec explicitly mandates in-memory-only preview storage (FR-034). The Map is lightweight, bounded by the number of users with a pending preview (typically very low), and makes accept/reject synchronous O(1) lookups. Extracting the Map to a dedicated module allows `generation.service.js` and `roadmapAcceptance.service.js` to both access it without circular imports.
+**Rationale**: No `roadmap_previews` MongoDB collection — preview remains ephemeral by design. Decoupling acceptance from in-memory preview makes the contract fork-consumable and robust to preview-loss scenarios.
 
 **Pattern**:
 ```js
@@ -257,7 +257,7 @@ function getAllPendingUserIds() {
 module.exports = { storePendingPreview, getPendingPreview, clearPendingPreview, getAllPendingUserIds };
 ```
 
-**Preview payload shape**:
+**Preview payload shape** (unchanged):
 ```js
 {
   nodes: RoadmapNode[],            // AI output with resources: [] appended
@@ -322,3 +322,86 @@ notifyUser(userId, 'roadmap_generation_failed', {
 - Polling endpoint (`GET /api/roadmap/status`) (rejected — SSE is already in place from Feature 001/005; polling adds unnecessary server load)
 - Separate SSE endpoint for roadmap events (rejected — duplicates connection management; Feature 005's notification module is designed for cross-feature consumption)
 - WebSocket (rejected — bidirectional channel is overkill for one-way server→client push)
+
+---
+
+## R-006: Multi-Roadmap Model + Single Primary Invariant
+
+**Decision**: Move from single roadmap per user to multi-roadmap per user, with `isPrimary` boolean and a partial unique index enforcing exactly one primary roadmap per user.
+
+**Rationale**: Multi-roadmap supports version history and forked variants while preserving deterministic consumer behavior (`GET /api/primary-roadmap`).
+
+**Pattern**:
+```js
+// backend/src/modules/roadmap/roadmap.model.js
+roadmapSchema.index(
+  { userId: 1, isPrimary: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { isPrimary: true },
+    name: 'primary_per_user_unique',
+  }
+);
+
+roadmapSchema.index(
+  { userId: 1, status: 1, updatedAt: -1 },
+  { name: 'roadmap_list_by_user_status_updatedAt' }
+);
+```
+
+**Alternatives considered**:
+- Keep unique `{ userId: 1 }` (rejected — blocks history/forks)
+- Store primary pointer on `users` collection (rejected — cross-collection consistency overhead)
+
+---
+
+## R-007: Fork-Consumable Acceptance Pipeline (No Preview-Accept Endpoint)
+
+**Decision**: Replace old preview-accept endpoint with payload-based acceptance endpoint receiving full `RoadmapNode[]` from caller. Enforce canonical pipeline: `filterCompletedCourses` → `validatePrerequisites` → `commitRoadmap`.
+
+**Rationale**: Contract becomes reusable by any producer/consumer fork and independent from volatile in-memory preview state.
+
+**Pattern**:
+```js
+// backend/src/modules/roadmap/roadmapAcceptance.service.js
+async function acceptRoadmapPayload(userId, payload) {
+  const filteredNodes = filterCompletedCourses(payload.nodes, payload.completedCourseCodes);
+  if (filteredNodes.length === 0) {
+    throw createDomainError('ALL_COMPLETED', 'All submitted nodes are already completed.');
+  }
+
+  const validation = validatePrerequisites(filteredNodes, payload.courseUnits);
+  if (!validation.ok) {
+    throw createDomainError('PREREQUISITE_VIOLATION', validation.message);
+  }
+
+  return commitAcceptedRoadmap(userId, {
+    ...payload,
+    nodes: filteredNodes,
+  });
+}
+```
+
+**Error normalization**:
+- `PREREQUISITE_VIOLATION`
+- `ALL_COMPLETED`
+- `CONFLICT`
+- `ROADMAP_NOT_FOUND`
+
+**Alternatives considered**:
+- Continue using in-memory preview accept (rejected — not fork-consumable)
+- Client-only validation before commit (rejected — canonical rules must be enforced server-side)
+
+---
+
+## R-008: Canonical Transition Authority in Feature 009
+
+**Decision**: Feature 009 owns lifecycle transition rules and conflict semantics. Other features only call contracts.
+
+**Rationale**: Prevents divergent transition logic between onboarding, skill tree, and account modules.
+
+**Guardrail**:
+```text
+No module outside /modules/roadmap may mutate roadmaps collection directly.
+All mutations must pass roadmap.service.js / roadmapAcceptance.service.js.
+```

--- a/specs/009-roadmap-generator/spec.md
+++ b/specs/009-roadmap-generator/spec.md
@@ -15,10 +15,11 @@
 - Q: Who or what surfaces the retry trigger to the student? → A: Both — the in-app error notification carries a retry call-to-action, AND the Skill Tree (Feature 004) exposes a retry action whenever the roadmap status is `failed`.
 - Q: Should `supportingSkills` be deduplicated across the whole roadmap, or scoped independently per node? → A: Each node's `supportingSkills` is independently scoped — the same skill may appear on multiple nodes if it is genuinely relevant to each. Deduplication is a presentation concern owned by Feature 004.
 - Q4 dropped — automatic upgrade of low-personalisation roadmap when profile is enriched is a frontend/rendering concern; not in scope for this backend feature.
-- Decision: All generated roadmaps (initial and re-generation) require explicit student acceptance before being committed to the main roadmap store. The pre-acceptance state (RoadmapPreview) is transient and not persisted in the main collection. One user holds at most one Roadmap document in the main collection at any time.
+- Decision: All generated roadmaps (initial and re-generation) require explicit student acceptance before commit. The pre-acceptance state (RoadmapPreview) remains transient and not persisted in the main collection. A user may hold multiple roadmap documents, but exactly one roadmap is primary at any time.
 - Decision: Re-generation triggered by `repersonalizationPending` uses the student's existing accepted roadmap as additional AI context. The previous roadmap remains active until the student accepts the new preview; it is preserved unchanged if the student rejects the preview.
 - Q: Where does the RoadmapPreview live and does it expire? → A: The preview is held in-memory on the background worker only. It does not survive a worker restart and is not readable cross-session. A worker restart while a preview is pending is treated as a generation failure; the retry mechanism becomes available.
 - Q: If no accepted roadmap exists when `repersonalizationPending` triggers re-generation, what happens? → A: Re-generation proceeds as a fresh initial generation — StudentProfile and DAG are the only inputs; no base roadmap context is provided to the AI. This is not an error.
+- Decision (canonical ownership): Feature 009 is the sole owner of roadmap lifecycle/state-transition rules. All other features consume roadmap data via 009 API/service contract only.
 
 ---
 
@@ -40,7 +41,7 @@ When a student submits their full onboarding profile (including career goal, com
 4. **Given** the course selection is complete, **When** the roadmap nodes are ordered, **Then** every node appears after all of its prerequisite nodes in the sequence, with no exceptions.
 5. **Given** every selected node is ordered, **When** the AI enriches each node, **Then** each node has a gainedSkills list (skills taught by the course), a supportingSkills list (skills NOT in the course but needed in practice for the career goal), a reason, a careerRelevanceNote, and an empty resources array.
 6. **Given** generation completes successfully, **When** the AI output is validated, **Then** a roadmap preview is prepared and the student receives an in-app notification that their roadmap is ready for review.
-7. **Given** the student reviews the roadmap preview, **When** the student accepts it, **Then** the roadmap is committed as the student's active Roadmap document, linked to their userId, replacing any previous document.
+7. **Given** the student reviews the roadmap payload, **When** the student accepts it through the 009 acceptance contract, **Then** the roadmap is committed as a Roadmap document and may become primary according to primary-selection rules.
 8. **Given** the student reviews the roadmap preview, **When** the student rejects it, **Then** the preview is discarded, any existing roadmap remains unchanged, and the retry mechanism becomes available.
 
 ---
@@ -60,7 +61,7 @@ A student submits their onboarding with only the required major field filled in 
 3. **Given** courses are selected in generic mode, **When** each node is enriched, **Then** gainedSkills are still course-specific, but supportingSkills contain only universally applicable best-practice recommendations rather than role-targeted guidance.
 4. **Given** generic generation completes, **When** the roadmap preview is prepared, **Then** it carries a low-personalisation flag.
 5. **Given** the roadmap preview is ready, **When** the student receives their notification, **Then** the notification includes an indication that personalisation quality is limited.
-6. **Given** the student reviews the generic roadmap preview, **When** the student accepts it, **Then** the roadmap is committed as the student's active Roadmap document carrying the low-personalisation flag.
+6. **Given** the student reviews the generic roadmap payload, **When** the student accepts it, **Then** the roadmap is committed carrying the low-personalisation flag and managed under the same primary-selection rules.
 
 ---
 
@@ -77,7 +78,7 @@ Roadmap generation fails due to an AI service error or timeout. The system store
 1. **Given** generation encounters a failure (AI service error, timeout, or malformed AI output), **When** the failure is detected, **Then** the system stores the error state on the Roadmap document without corrupting the student's profile.
 2. **Given** a failed generation state is stored, **When** the system finishes error handling, **Then** the student receives an in-app error notification.
 3. **Given** a failed Roadmap state exists, **When** the student triggers a retry, **Then** generation re-reads the existing StudentProfile and re-runs the full generation lifecycle.
-4. **Given** a retry generation completes successfully, **When** the new Roadmap is stored, **Then** it fully replaces the previous failed state — no residual error data persists.
+4. **Given** a retry generation completes successfully, **When** the accepted roadmap is committed, **Then** canonical transition rules are applied and stale failure state is not exposed as the latest accepted version.
 5. **Given** the student has not resubmitted their profile, **When** they initiate a retry, **Then** the system uses the same StudentProfile as the original attempt.
 
 ---
@@ -95,7 +96,7 @@ After a student updates their career goal in Account Settings, the `repersonaliz
 1. **Given** a student's career goal has been updated and repersonalizationPending is true, **When** re-generation is triggered, **Then** it runs asynchronously without blocking the student, and the existing accepted roadmap is provided to the AI as additional context.
 2. **Given** re-generation is in progress, **When** the AI generates the updated roadmap, **Then** it uses the updated career goal from the current StudentProfile and the existing accepted roadmap as a base; the previous course selections inform but do not constrain the new output.
 3. **Given** re-generation completes successfully, **When** the roadmap preview is ready, **Then** the student receives an in-app notification that their updated roadmap is ready for review.
-4. **Given** the student reviews the updated roadmap preview, **When** the student accepts it, **Then** the preview replaces the previous roadmap as the student's active Roadmap document, and repersonalizationPending is cleared on the StudentProfile.
+4. **Given** the student reviews the updated roadmap payload, **When** the student accepts it, **Then** the accepted roadmap is committed under canonical transition rules, primary assignment is consistent, and repersonalizationPending is cleared on the StudentProfile.
 5. **Given** the student reviews the updated roadmap preview, **When** the student rejects it, **Then** the preview is discarded, the previous roadmap remains the student's active roadmap unchanged, and repersonalizationPending is cleared.
 6. **Given** re-generation fails, **When** the failure is detected, **Then** the same retry mechanism is available as for initial generation failure, and the previous roadmap remains in the database unchanged.
 
@@ -163,8 +164,10 @@ After a student updates their career goal in Account Settings, the `repersonaliz
 **Output Storage**
 
 - **FR-022**: On successful generation, the system MUST create a roadmap preview. The preview MUST NOT be committed to the main roadmap collection until the student explicitly accepts it.
-- **FR-023**: A student MUST have at most one Roadmap document in the main roadmap collection at any time. Only an accepted roadmap preview may be committed as the student's active document, replacing any previous one.
+- **FR-023**: A student MAY have multiple Roadmap documents in the main roadmap collection. Exactly one roadmap per student MUST be marked primary (`isPrimary: true`) at all times.
 - **FR-024**: The Roadmap document stored in the main collection MUST record a `status` field. Valid persisted statuses are: `completed` (accepted and active) and `failed` (generation failure awaiting retry). Transient generation states are not persisted in the main roadmap collection.
+- **FR-024a**: The data model MUST include `isPrimary` and enforce one-primary-per-user with a partial unique index on `{ userId: 1, isPrimary: 1 }` filtered by `{ isPrimary: true }`.
+- **FR-024b**: The data model MUST include a list/query index supporting roadmap timeline retrieval by `{ userId: 1, status: 1, updatedAt: -1 }`.
 
 **Notifications**
 
@@ -175,7 +178,7 @@ After a student updates their career goal in Account Settings, the `repersonaliz
 **Retry Mechanism**
 
 - **FR-028**: On generation failure, the system MUST store the error state on the Roadmap document (status `failed`) so that the failure is readable by any consuming surface.
-- **FR-029**: The system MUST allow the student to trigger a retry of a failed generation without requiring the student to resubmit their profile. The retry action MUST be accessible from two surfaces: (1) any consuming surface that reads the retryable metadata from the failure notification (via FR-027), and (2) any consuming surface that reads `status: failed` from this feature's Roadmap API — including the Skill Tree view (Feature 004). This feature MUST expose the Roadmap `status` field through its API so that consumers can determine whether a retry affordance is appropriate.
+- **FR-029**: The system MUST allow the student to trigger a retry of a failed generation without requiring profile resubmission. Retryable state MUST be discoverable via 009 contracts.
 - **FR-030**: On retry, the system MUST re-read the existing StudentProfile and re-run the full generation lifecycle from the input retrieval step forward.
 
 **Re-Generation**
@@ -186,15 +189,21 @@ After a student updates their career goal in Account Settings, the `repersonaliz
 
 - **FR-032**: Roadmap generation MUST NEVER be blocked by the absence of Feature 003 (Resource Curation) data. The `resources` field on each node remains empty at generation time.
 - **FR-033**: Roadmap generation MUST be triggered entirely by internal system events — no student-facing API endpoint for initiating generation is permitted. The acceptance and rejection of a roadmap preview are student actions and MUST be served by dedicated API endpoints that this feature provides.
+- **FR-033a**: Feature 009 MUST expose canonical read APIs: `GET /api/primary-roadmap`, `GET /api/roadmaps`, and `GET /api/roadmaps/:roadmapId`.
+- **FR-033b**: Feature 009 MUST expose canonical primary-switch API: `PATCH /api/roadmaps/:roadmapId/primary`.
+- **FR-033c**: During migration, `GET /api/roadmap` MAY be kept as a compatibility alias for `GET /api/primary-roadmap` and MUST be documented as deprecated.
 
-**Preview Acceptance**
+**Acceptance / Commit Contract**
 
-- **FR-034**: Upon successful generation, the system MUST make the roadmap preview available for student review by delivering the full preview payload in the generation completion notification response. The preview is held in-memory on the background worker only — it is not persisted to any collection and does not survive a worker restart. If the worker restarts before the student accepts or rejects, the in-memory preview is lost and the generation is treated as failed (FR-028 applies).
-- **FR-035**: The student MUST be able to explicitly accept or reject a roadmap preview via this feature's preview acceptance API endpoints.
-- **FR-036**: On acceptance, the system MUST commit the previewed roadmap as the student's active Roadmap document (status `completed`), replacing any previously stored document in the main collection.
-- **FR-037**: On rejection of an initial generation preview (no previous active roadmap exists), the preview MUST be discarded. The student is left without an active roadmap; the retry mechanism (FR-028–FR-030) MUST remain available.
-- **FR-038**: On rejection of a re-generation preview, the preview MUST be discarded and the student's existing active Roadmap document MUST remain unchanged.
+- **FR-034**: Upon successful generation, the system MUST provide preview payload for review (notification-driven), but canonical acceptance MUST be payload-based and not depend on server-side preview lookup.
+- **FR-035**: The acceptance endpoint MUST receive full roadmap nodes payload from caller.
+- **FR-036**: Acceptance MUST execute mandatory server pipeline: (1) filter completed courses, (2) prerequisite validation, (3) commit roadmap document.
+- **FR-037**: If all submitted nodes are filtered out as completed, acceptance MUST fail with `ALL_COMPLETED`.
+- **FR-038**: If prerequisite or ordering constraints are violated, acceptance MUST fail with `PREREQUISITE_VIOLATION`.
+- **FR-038a**: Lifecycle conflicts (e.g., concurrent generation/primary update/duplicate state operation) MUST return `CONFLICT`.
 - **FR-039**: When re-generation is triggered via `repersonalizationPending`, the system MUST check whether the student has an existing accepted Roadmap document. If one exists, the system MUST supply it to the AI as additional context alongside the updated StudentProfile and full CourseUnit DAG. If no accepted Roadmap document exists (e.g., the student previously rejected all previews), the system MUST proceed as a fresh initial generation — StudentProfile and DAG only — without treating the absence of a base roadmap as an error.
+- **FR-040**: Feature 009 MUST be the only feature that defines and enforces roadmap state transitions.
+- **FR-041**: Acceptance and list/detail/primary APIs MUST use normalized domain error codes: `PREREQUISITE_VIOLATION`, `ALL_COMPLETED`, `CONFLICT`, `ROADMAP_NOT_FOUND`.
 
 ---
 
@@ -211,8 +220,8 @@ After a student updates their career goal in Account Settings, the `repersonaliz
 
 ### Key Entities
 
-- **Roadmap**: The accepted, active learning roadmap for a single student, stored in the main roadmap collection. Contains: `userId` (FK to Feature 005 User), `studentProfileId` (FK to Feature 001 StudentProfile), `personalisationLevel` (`full` | `low`), `status` (`completed` | `failed`), `errorMessage` (set on failure, null otherwise), an ordered array of `RoadmapNode` objects, and creation/acceptance timestamps.
-- **RoadmapPreview**: A transient, in-memory representation of a newly generated roadmap awaiting student acceptance. It is held in-memory on the background worker only — it is NOT stored in any collection and does NOT survive a worker restart. The full preview payload is delivered to Feature 004 (Skill Tree) via the generation completion notification so the student can review it. On acceptance it is committed as the active Roadmap document; on rejection or worker restart it is discarded and treated as a generation failure.
+- **Roadmap**: A roadmap version document owned by Feature 009. Contains: `userId`, `studentProfileId`, `personalisationLevel`, `status`, `isPrimary`, `errorMessage`, ordered `RoadmapNode[]`, and timestamps.
+- **RoadmapPreview**: A transient, in-memory representation for review UX. It is not canonical persistence and not required as acceptance source.
 - **RoadmapNode**: A single enriched course entry within the roadmap's ordered sequence. Contains: `courseCode`, `courseName`, `credits`, `suggestedSemester`, `gainedSkills` (array of strings), `supportingSkills` (array of strings), `reason` (string), `careerRelevanceNote` (string), and `resources` (always an empty array at generation time).
 - **RoadmapGenerationEvent**: The triggering event that initiates a generation run. Carries: `userId`, `studentProfileId`, and `triggerReason` (`profile_submission` | `retry` | `repersonalization`). This event is emitted by Feature 001 on submission and by the retry/repersonalization mechanisms.
 


### PR DESCRIPTION
Refine all Feature 009 artifacts to establish roadmap lifecycle authority, move to multi-roadmap persistence with single-primary invariant, and standardize acceptance + API contracts for fork-consumable flows.

Updated artifacts:
- specs/009-roadmap-generator/spec.md
- specs/009-roadmap-generator/plan.md
- specs/009-roadmap-generator/data-model.md
- specs/009-roadmap-generator/contracts/rest-api.md
- specs/009-roadmap-generator/research.md

Key changes:
1) Canonical ownership and lifecycle authority
- Declare Feature 009 as the only source of truth for roadmap state transitions and persistence semantics.
- Clarify that other features must consume via 009 API/service contracts and must not write roadmaps directly.

2) Multi-roadmap model + single primary roadmap
- Replace single-roadmap-per-user assumption with multi-roadmap-per-user.
- Add `isPrimary` semantics.
- Add partial unique index for one-primary-per-user: { userId: 1, isPrimary: 1 } + partialFilterExpression { isPrimary: true }.
- Add list/query index for timeline retrieval: { userId: 1, status: 1, updatedAt: -1 }.
- Document primary invariant and transactional promote/demote behavior.

3) API contract redesign
- Introduce canonical primary endpoint: GET /api/primary-roadmap
- Keep compatibility note for deprecated alias: GET /api/roadmap
- Add multi-roadmap endpoints: GET /api/roadmaps GET /api/roadmaps/:roadmapId PATCH /api/roadmaps/:roadmapId/primary

4) Fork-consumable acceptance flow (payload-based)
- Replace old preview-accept dependency with endpoint accepting full roadmap nodes payload.
- Enforce mandatory server pipeline: filter completed -> prerequisite validation -> commit.
- Normalize domain errors: PREREQUISITE_VIOLATION, ALL_COMPLETED, CONFLICT, ROADMAP_NOT_FOUND.

5) Research/plan/data-model alignment
- Update research decisions to reflect canonical ownership, multi-roadmap indexing strategy, and payload-based acceptance.
- Reframe in-memory preview store as transient UX cache only (not commit source of truth).
- Align plan scope, architecture, test focus, and performance targets with new lifecycle/API model.