### PR TITLE
docs(skill-tree): align feature 004 with canonical roadmap ownership in feature 009

### DIFF
--- a/specs/004-skill-tree/contracts/rest-api.md
+++ b/specs/004-skill-tree/contracts/rest-api.md
@@ -5,6 +5,8 @@
 
 All endpoints require `Authorization: Bearer <JWT>` header. The JWT is issued by the auth system (Feature 001). The payload includes `userId`.
 
+Roadmap topology is consumed from Feature 009 canonical contract (`GET /api/primary-roadmap` or equivalent service-layer adapter). Feature 004 does not read a local `student_roadmaps` collection.
+
 Base path: `/api/skill-tree`
 
 ---
@@ -26,6 +28,8 @@ No query parameters. No request body.
 
 ```json
 {
+  "roadmapId": "rm_frontend_2026_v1",
+  "roadmapName": "Frontend Developer Roadmap",
   "careerGoal": "frontend-developer",
   "needsRepersonalization": false,
   "repersonalizing": false,
@@ -62,9 +66,10 @@ No query parameters. No request body.
 ```
 
 **Field notes**:
-- `needsRepersonalization`: `true` when `studentProfile.updatedAt > studentRoadmap.generatedAt`.
-- `repersonalizing`: `true` in the brief window after `POST /api/skill-tree/repersonalize` returns and before the job completes (tracked via `studentRoadmap.repersonalizing` flag on the document).
-- `status`: `"pending"` (default when no document in `skill_node_statuses`), `"in_progress"`, or `"done"`.
+- `roadmapId`/`roadmapName`: passthrough identifiers from Feature 009 canonical primary roadmap.
+- `needsRepersonalization`: `true` when `studentProfile.updatedAt > primaryRoadmap.generatedAt`.
+- `repersonalizing`: passthrough from canonical roadmap metadata (`primaryRoadmap.repersonalizing`).
+- `status`: always one of explicit persisted records in `skill_node_statuses`: `"pending"`, `"in_progress"`, or `"done"`.
 - `isUnlocked`: computed server-side; `true` when all `prerequisites` are `"done"` in the student's status records, or when `prerequisites` is empty.
 
 ### Responses — Error Cases
@@ -73,7 +78,7 @@ No query parameters. No request body.
 |---|---|
 | `401 Unauthorized` | Missing or invalid JWT |
 | `403 Forbidden` | JWT valid but `studentProfile.isDraft === true` (onboarding not submitted yet) |
-| `404 Not Found` | No `student_roadmaps` document for this student (personalization has not run); body: `{ "error": "ROADMAP_NOT_FOUND" }` |
+| `404 Not Found` | No canonical primary roadmap from Feature 009 for this student; body: `{ "error": "PRIMARY_ROADMAP_NOT_FOUND" }` |
 
 ---
 
@@ -114,7 +119,7 @@ Content-Type: application/json
 | `400 Bad Request` | `status` field missing or not a valid enum value; or transition is not `pending → in_progress → done` (e.g., `done → in_progress`) |
 | `401 Unauthorized` | Missing or invalid JWT |
 | `403 Forbidden` | Node is locked (`isUnlocked === false`) |
-| `404 Not Found` | `courseCode` does not exist in the student's roadmap |
+| `404 Not Found` | `courseCode` does not exist in the student's primary roadmap |
 
 ---
 
@@ -160,7 +165,7 @@ Authorization: Bearer <JWT>
 | Status | Condition |
 |---|---|
 | `401 Unauthorized` | Missing or invalid JWT |
-| `404 Not Found` | `courseCode` not in the student's roadmap |
+| `404 Not Found` | `courseCode` not in the student's primary roadmap |
 
 ---
 
@@ -198,7 +203,7 @@ Authorization: Bearer <JWT>
 | Status | Condition |
 |---|---|
 | `401 Unauthorized` | Missing or invalid JWT |
-| `404 Not Found` | `courseCode` not in the student's roadmap |
+| `404 Not Found` | `courseCode` not in the student's primary roadmap |
 | `502 Bad Gateway` | Gemini API call failed (cache miss path only); body: `{ "error": "AI_SERVICE_UNAVAILABLE" }` |
 
 ---
@@ -238,7 +243,7 @@ Authorization: Bearer <JWT>
 | Status | Condition |
 |---|---|
 | `401 Unauthorized` | Missing or invalid JWT |
-| `404 Not Found` | `courseCode` not in the student's roadmap |
+| `404 Not Found` | `courseCode` not in the student's primary roadmap |
 
 ---
 
@@ -295,7 +300,7 @@ Authorization: Bearer <JWT>
 
 ## Endpoint 7 — POST /api/skill-tree/repersonalize
 
-Triggers re-generation of the student's personalized roadmap. Only available when `needsRepersonalization === true`.
+Triggers re-generation of the student's canonical primary roadmap via Feature 009. Only available when `needsRepersonalization === true`.
 
 ### Request
 
@@ -316,9 +321,9 @@ No body required.
 ```
 
 **Server-side actions on 202**:
-1. Set `studentRoadmap.generatedAt = Date.now()` and `studentRoadmap.repersonalizing = true` immediately (prevents button reappearing on next poll).
-2. Dispatch personalization job asynchronously (Promise-based, same pattern as Feature 001 roadmap trigger).
-3. Job completion: updates `studentRoadmap.nodes[]`, clears `repersonalizing: false`, sets final `generatedAt`.
+1. Delegate re-personalization trigger to Feature 009 canonical roadmap service (async).
+2. Feature 009 sets/maintains canonical `repersonalizing` and final `generatedAt`.
+3. After primary roadmap changes, Feature 004 reconciles `skill_node_statuses` to explicit records for the new node set (upsert new nodes with `pending`, remove obsolete node records).
 
 The frontend continues polling `GET /api/skill-tree` every 2500ms; when `repersonalizing` becomes `false` and the new nodes array is present, the tree re-renders automatically.
 
@@ -329,3 +334,43 @@ The frontend continues polling `GET /api/skill-tree` every 2500ms; when `reperso
 | `401 Unauthorized` | Missing or invalid JWT |
 | `403 Forbidden` | `needsRepersonalization === false` (profile has not been updated since last personalization) |
 | `409 Conflict` | Re-personalization already in progress (`repersonalizing === true`) |
+
+---
+
+## Downstream Service Contract — `getNodesByStatus()`
+
+This is a service-layer contract for downstream modules (not a public HTTP endpoint in this document).
+
+### Return shape
+
+```json
+{
+  "roadmapId": "rm_frontend_2026_v1",
+  "roadmapName": "Frontend Developer Roadmap",
+  "done": [
+    {
+      "nodeId": "IT1010",
+      "courseCode": "IT1010",
+      "courseName": "Nhập môn lập trình",
+      "status": "done",
+      "updatedAt": "2026-03-11T09:00:00.000Z"
+    }
+  ],
+  "inProgress": [
+    {
+      "nodeId": "IT3910E",
+      "courseCode": "IT3910E",
+      "courseName": "Lập trình Web",
+      "status": "in_progress",
+      "updatedAt": "2026-03-12T09:00:00.000Z"
+    }
+  ],
+  "pending": []
+}
+```
+
+### Contract rules
+
+- Always return all three arrays: `done`, `inProgress`, `pending` (even when empty).
+- Every node item uses the same shape: `nodeId`, `courseCode`, `courseName`, `status`, `updatedAt`.
+- `roadmapId` and `roadmapName` are always included from Feature 009 canonical roadmap metadata.

--- a/specs/004-skill-tree/data-model.md
+++ b/specs/004-skill-tree/data-model.md
@@ -1,22 +1,22 @@
 # Data Model: Skill Tree – Personalized Academic Roadmap Tracker
 
 **Phase 1 output** | Branch: `004-skill-tree` | Date: 2026-03-11  
-**Research dependency**: [research.md](research.md) (Decisions 1–8)
+**Research dependency**: [research.md](research.md) (Decisions 1–9)
 
 ---
 
-## MongoDB Collections
+## Data Sources and Persistence
 
-### 1. `skill_node_statuses` *(new — owned by this feature)*
+### 1. `skill_node_statuses` *(canonical progress store — owned by this feature)*
 
-Stores one document per (student, course node) pair. Absent documents imply status `"pending"`.
+Stores one document per (student, roadmap node) pair. `pending` is explicit; missing documents are treated as data drift and reconciled by sync logic.
 
 ```js
 // Mongoose schema: backend/src/modules/skill-tree/skillNodeStatus.model.js
 {
   _id:       ObjectId,          // auto
   studentId: ObjectId,          // required — ref: users (from Feature 001)
-  nodeId:    String,            // required — matches courseCode in student_roadmaps.nodes[].courseCode
+  nodeId:    String,            // required — matches primaryRoadmap.nodes[].nodeId (or courseCode when unified)
   status:    String,            // required — enum: ["pending", "in_progress", "done"]
   updatedAt: Date               // required — set manually on every write
 }
@@ -31,36 +31,40 @@ Stores one document per (student, course node) pair. Absent documents imply stat
 **Business rules** (enforced by service layer, not schema):
 - A status update is rejected (`403 Forbidden`) if computed `isUnlocked(node) === false` for the requesting student.
 - State transitions allowed: `pending → in_progress → done`. No skips, no reversals.
-- `"pending"` is the implicit default — no document = pending; documents with `status: "pending"` may exist after a re-personalization cycle.
+- `"pending"` is explicit — every node in the primary roadmap must have a persisted status row.
+- On primary roadmap refresh, status rows are reconciled: upsert `pending` for newly introduced nodes and remove rows for deleted nodes.
 
 ---
 
-### 2. `student_roadmaps` *(new — owned by personalization job, read by this feature)*
+### 2. Primary roadmap contract *(external — owned by Feature 009, read by this feature)*
 
-One document per student. Written by the onboarding/personalization service (external to this feature). Read on every `GET /api/skill-tree` call.
+Feature 004 does not persist roadmap topology locally. It consumes canonical roadmap data from Feature 009 via `GET /api/primary-roadmap` (or equivalent service-layer adapter).
 
 ```js
-// Read-only from Feature 004's perspective
+// Read-only payload contract consumed by Feature 004
 {
-  _id:           ObjectId,
-  studentId:     ObjectId,          // unique — ref: users
-  careerGoal:    String,            // e.g., "frontend-developer" — used as key for AI prompts
+  roadmapId:      String,
+  roadmapName:    String,
+  careerGoal:     String,
   nodes: [
     {
-      courseCode:    String,        // e.g., "IT3910E" — uniquely identifies the course
-      nameVi:        String,        // Vietnamese name (primary)
-      nameEn:        String,        // English name
-      credits:       Number,
-      prerequisites: [String]       // array of courseCodes in this roadmap
+      nodeId:         String,
+      courseCode:     String,
+      courseName:     String,
+      nameVi:         String,
+      nameEn:         String,
+      credits:        Number,
+      prerequisites:  [String]
     }
   ],
-  generatedAt:   Date               // set when personalization job completes; used for re-personalize flag
+  generatedAt:    Date,
+  repersonalizing:Boolean
 }
 ```
 
 **Access pattern (this feature)**:
-- `findOne({ studentId })` on `GET /api/skill-tree` → returns full roadmap; `null` → 404 (redirect to onboarding)
-- `findOneAndUpdate({ studentId }, { generatedAt: Date.now() })` on `POST /api/skill-tree/repersonalize` (optimistic timestamp update while job runs)
+- `getPrimaryRoadmap(studentId)` on `GET /api/skill-tree` and all node-scoped read/write endpoints.
+- `triggerRepersonalize(studentId)` delegation on `POST /api/skill-tree/repersonalize`.
 
 ---
 
@@ -166,20 +170,20 @@ One document per skill. Contains curated or crawled learning resources (free and
 
 ### `student_profiles` *(maintained by Feature 001)*
 
-Read for the re-personalize flag computation: `findOne({ userId })` → use `updatedAt` field.
+Read for the re-personalize flag computation: `findOne({ userId })` → compare with `primaryRoadmap.generatedAt` from Feature 009.
 
 Relevant fields only:
 ```js
 {
   userId:     ObjectId,
-  updatedAt:  Date,      // compared to student_roadmaps.generatedAt
+  updatedAt:  Date,      // compared to primaryRoadmap.generatedAt
   isDraft:    Boolean    // guard: don't allow skill tree access if true (onboarding not submitted)
 }
 ```
 
 ### `course_units` *(seeded by Feature 002)*
 
-Not directly queried by this feature. Course metadata (`nameVi`, `nameEn`, `credits`, `prerequisites`) is embedded into `student_roadmaps.nodes[]` by the personalization job to avoid a join at render time.
+Not directly queried by this feature. Course metadata (`nameVi`, `nameEn`, `credits`, `prerequisites`) is embedded into Feature 009 primary roadmap nodes to avoid a join at render time in Feature 004.
 
 ---
 
@@ -209,7 +213,8 @@ Not directly queried by this feature. Course metadata (`nameVi`, `nameEn`, `cred
 | `in_progress → pending` | Reversal not permitted | `400 Bad Request` |
 
 **`isUnlocked` computation** (server-side, O(V + E)):
-- Fetch all `skill_node_statuses` for the student.
+- Fetch primary roadmap nodes from Feature 009 and fetch all `skill_node_statuses` for that roadmap/student.
+- Reconcile missing rows first (upsert explicit `pending` status rows for any node without a record).
 - For each node in the roadmap: `isUnlocked = prerequisites.every(prereqCode => status[prereqCode] === 'done')`.
 - Nodes with empty `prerequisites` array are **always unlocked**.
 
@@ -222,8 +227,52 @@ Computed on every `GET /api/skill-tree` response:
 ```js
 const needsRepersonalization =
   studentProfile.isDraft === false &&
-  studentRoadmap !== null &&
-  studentProfile.updatedAt > studentRoadmap.generatedAt;
+  primaryRoadmap !== null &&
+  studentProfile.updatedAt > primaryRoadmap.generatedAt;
 ```
 
 Included in the response body alongside the node array.
+
+---
+
+## Downstream Contract: `getNodesByStatus()`
+
+Service-layer contract exposed by Feature 004 for downstream consumers:
+
+```js
+{
+  roadmapId: String,
+  roadmapName: String,
+  done: [
+    {
+      nodeId: String,
+      courseCode: String,
+      courseName: String,
+      status: "done",
+      updatedAt: Date
+    }
+  ],
+  inProgress: [
+    {
+      nodeId: String,
+      courseCode: String,
+      courseName: String,
+      status: "in_progress",
+      updatedAt: Date
+    }
+  ],
+  pending: [
+    {
+      nodeId: String,
+      courseCode: String,
+      courseName: String,
+      status: "pending",
+      updatedAt: Date
+    }
+  ]
+}
+```
+
+Rules:
+- Always return all three arrays (`done`, `inProgress`, `pending`) even when empty.
+- Node payload shape is uniform across groups: `{ nodeId, courseCode, courseName, status, updatedAt }`.

--- a/specs/004-skill-tree/plan.md
+++ b/specs/004-skill-tree/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Build an interactive, personalized Skill Tree that renders a student's UET academic roadmap as a top-down DAG. Each node represents a UET course from a per-student personalized roadmap JSON stored in `student_roadmaps`. Node states (`pending`/`in_progress`/`done`) are persisted in `skill_node_statuses`; unlock logic is computed server-side via DAG traversal (O(V + E)). Clicking a node opens a three-tab detail panel: (1) admin-seeded course resources, (2) on-demand Gemini-generated "Why This Course" explanation cached by `{courseCode, careerGoal}` in `course_ai_contexts`, and (3) market skills from Vietnamese job platform data with drill-down learning resources. A "Re-personalize" button appears when `studentProfile.updatedAt > studentRoadmap.generatedAt` and triggers asynchronous roadmap regeneration; the frontend detects completion via 2500ms polling.
+Build an interactive, personalized Skill Tree that renders a student's UET academic roadmap as a top-down DAG. Feature 004 consumes canonical roadmap topology from Feature 009 (`GET /api/primary-roadmap` or service-layer equivalent) and does not own roadmap storage. Node states (`pending`/`in_progress`/`done`) are canonical in `skill_node_statuses` with explicit persisted `pending` records for every roadmap node; unlock logic is computed server-side via DAG traversal (O(V + E)). Clicking a node opens a three-tab detail panel: (1) admin-seeded course resources, (2) on-demand Gemini-generated "Why This Course" explanation cached by `{courseCode, careerGoal}` in `course_ai_contexts`, and (3) market skills from Vietnamese job platform data with drill-down learning resources. A "Re-personalize" button appears when `studentProfile.updatedAt > primaryRoadmap.generatedAt`; Feature 004 delegates regeneration to Feature 009 and detects completion via 2500ms polling.
 
 ## Technical Context
 
@@ -14,7 +14,7 @@ Build an interactive, personalized Skill Tree that renders a student's UET acade
 - Backend: Express.js, Mongoose 8, `@google/generative-ai` (Gemini SDK — for "Why This Course" on-demand generation), `jsonwebtoken` (existing auth middleware from Feature 001)
 - Frontend: React 18, React Router v6, `@xyflow/react` v12 (React Flow), Zustand 4 with `persist` middleware, Tailwind CSS (bundled with Vite)
 
-**Storage**: MongoDB Atlas free tier — new collections: `skill_node_statuses`, `course_ai_contexts`, `course_resources`; read-only: `student_roadmaps` (written by personalization job), `market_skills`, `skill_learning_resources` (written by crawling service), `student_profiles` (Feature 001)  
+**Storage**: MongoDB Atlas free tier — new collections: `skill_node_statuses`, `course_ai_contexts`, `course_resources`; read-only collections: `market_skills`, `skill_learning_resources` (written by crawling service), `student_profiles` (Feature 001). Canonical roadmap data is consumed from Feature 009 via API/service contract (not from a local collection).  
 **Testing**: Jest — unit tests only; MongoDB, Gemini SDK, and auth middleware all mocked; no external services required to run tests  
 **Target Platform**: Backend → Render (Node.js web service, free tier, cold start ~50s); Frontend → Vercel (React SPA)  
 **Project Type**: Web application — React SPA + Node.js/Express modular-monolith backend  
@@ -26,11 +26,11 @@ Build an interactive, personalized Skill Tree that renders a student's UET acade
 
 *Pre-design gate — re-checked after Phase 1 design: all items pass.*
 
-- [x] **I — Modular Monolithic**: All backend code lives in `backend/src/modules/skill-tree/`. Cross-module dependencies are: (1) `auth.middleware.js` from the middleware layer (not a domain module), (2) `studentProfileService.findByUserId()` called through the service layer only — no direct import of onboarding module internals. No new top-level packages or microservices.
+- [x] **I — Modular Monolithic**: All backend code lives in `backend/src/modules/skill-tree/`. Cross-module dependencies are: (1) `auth.middleware.js` from the middleware layer (not a domain module), (2) `studentProfileService.findByUserId()` via service layer, (3) Feature 009 primary-roadmap adapter via service layer only. No direct model imports across modules. No new top-level packages or microservices.
 - [x] **II — UET-First**: Course codes, Vietnamese names, and career goal identifiers are all UET-VNU specific. Market skills are sourced from Vietnamese IT job platforms (TopDev, ITviec). No abstraction for other universities or locales.
 - [x] **III — Privacy by Minimalism**: `skill_node_statuses` stores only `{ studentId, nodeId, status, updatedAt }`. The Gemini prompt for "Why This Course" contains only course metadata (`nameVi`, `nameEn`, `credits`) and `careerGoal` — no student personal data (no name, no transcript, no credentials). No new personal data fields beyond what is strictly needed.
 - [x] **IV — AI-Assisted, Human-Controlled**: Gemini is called only for "Why This Course" tab content — a descriptive explanation, not a decision-maker. Gemini output is validated before caching (length ≥ 50 chars, no refusal pattern). Students retain full manual control over node states (override by clicking). DAG unlock logic and re-personalize trigger are pure code — no LLM.
-- [x] **V — Test What Matters**: Unit tests mandatory for: DAG unlock computation (single prereq, multi-prereq, diamond DAG), state transition guard (locked node rejection, invalid transition), AI context cache hit/miss path, and re-personalize flag computation (`updatedAt` comparison). All dependencies mocked — no external service required.
+- [x] **V — Test What Matters**: Unit tests mandatory for: DAG unlock computation (single prereq, multi-prereq, diamond DAG), explicit pending reconciliation (all roadmap nodes have persisted status rows), state transition guard (locked node rejection, invalid transition), AI context cache hit/miss path, re-personalize flag computation (`updatedAt` comparison against primary roadmap), and `getNodesByStatus()` contract shape (always 3 arrays). All dependencies mocked — no external service required.
 
 ## Project Structure
 
@@ -40,11 +40,11 @@ Build an interactive, personalized Skill Tree that renders a student's UET acade
 specs/004-skill-tree/
 ├── plan.md              ← this file
 ├── spec.md              ← feature requirements
-├── research.md          ← Phase 0: 8 decisions resolved
-├── data-model.md        ← Phase 1: 6 MongoDB collections + state machine
+├── research.md          ← Phase 0: 9 decisions resolved
+├── data-model.md        ← Phase 1: canonical roadmap contract + progress data model + state machine
 ├── quickstart.md        ← Phase 1: local dev setup + manual test guide
 ├── contracts/
-│   └── rest-api.md      ← Phase 1: 7 endpoint contracts
+│   └── rest-api.md      ← Phase 1: 7 endpoint contracts + downstream service contract
 └── tasks.md             ← Phase 2 output (/speckit.tasks — NOT created here)
 ```
 
@@ -57,7 +57,8 @@ backend/
 │       └── skill-tree/
 │           ├── skillNodeStatus.model.js        # Mongoose schema: skill_node_statuses collection
 │           ├── aiContext.model.js               # Mongoose schema: course_ai_contexts collection
-│           ├── skillTree.service.js             # DAG traversal, unlock, state guard, repersonalize flag
+│           ├── skillTree.service.js             # DAG traversal, explicit pending sync, state guard, repersonalize flag
+│           ├── primaryRoadmap.service.js        # Adapter: consume Feature 009 canonical roadmap API/service
 │           ├── aiContext.service.js             # Gemini "Why This Course" + cache read/write
 │           ├── courseResource.service.js        # Read course_resources collection
 │           ├── marketSkill.service.js           # Read market_skills + skill_learning_resources
@@ -70,7 +71,9 @@ backend/
             ├── dagTraversal.test.js             # isUnlocked: single prereq, multi-prereq, diamond DAG, no prereqs
             ├── stateGuard.test.js               # Locked node → 403; invalid transition → 400; valid → pass
             ├── aiContextCache.test.js           # Cache hit (no Gemini call); cache miss (Gemini called + validation)
-            └── repersonalizeFlag.test.js        # updatedAt > generatedAt → true; equal or older → false; null roadmap
+            ├── repersonalizeFlag.test.js        # updatedAt > generatedAt(primary roadmap) → true; equal or older → false
+            ├── pendingSync.test.js              # explicit pending upsert for missing node status rows
+            └── getNodesByStatus.test.js         # roadmapId/roadmapName + done/inProgress/pending arrays always present
 
 frontend/
 ├── src/
@@ -93,7 +96,7 @@ frontend/
 │                                               #   getWhyCourse, getMarketSkills, getLearningResources, repersonalize
 ```
 
-**Structure Decision**: Option 2 — Web application. Modular monolith backend with all Skill Tree logic isolated in `backend/src/modules/skill-tree/`. Feature-folder structure on the frontend mirrors the backend module boundary and is consistent with Feature 001 (`frontend/src/features/<module>`). The `/skill-tree` route is registered in the root React Router setup. Communication from `skill-tree` to the `onboarding` module (`studentProfile.updatedAt` read) passes through `studentProfileService` called from `skillTree.service.js` — no direct cross-module import of schemas or models.
+**Structure Decision**: Option 2 — Web application. Modular monolith backend with all Skill Tree logic isolated in `backend/src/modules/skill-tree/`. Feature-folder structure on the frontend mirrors the backend module boundary and is consistent with Feature 001 (`frontend/src/features/<module>`). The `/skill-tree` route is registered in the root React Router setup. Communication from `skill-tree` to other domains is service-layer only: `studentProfileService` (Feature 001) and `primaryRoadmapService` (Feature 009), with no cross-module schema/model imports.
 
 ## Complexity Tracking
 

--- a/specs/004-skill-tree/research.md
+++ b/specs/004-skill-tree/research.md
@@ -6,20 +6,20 @@ All NEEDS CLARIFICATION items from Technical Context are resolved below. No rema
 
 ---
 
-## Decision 1: Personalized roadmap JSON — storage and consumption
+## Decision 1: Canonical roadmap ownership — consume from Feature 009
 
-**Decision**: The personalized roadmap is stored in a MongoDB collection `student_roadmaps` as one document per student. It is written by the onboarding/personalization job (out of scope) and read by this feature. The document contains the student's career goal, ordered node list (each with `courseCode`, `nameVi`, `nameEn`, `prerequisites[]`), and a `generatedAt` timestamp.
+**Decision**: Feature 004 does **not** own or read a local `student_roadmaps` collection. Skill Tree consumes the canonical roadmap from Feature 009 through `GET /api/primary-roadmap` (or an equivalent service-layer adapter). The response is treated as the single source of truth for `roadmapId`, `roadmapName`, `careerGoal`, ordered nodes, and roadmap freshness metadata (`generatedAt`, `repersonalizing`).
 
 **Rationale**:
-- Feature 003 used static hardcoded career-path JSON files. Feature 004 requires per-student personalization — the personalized roadmap must be student-scoped and mutable over time (re-personalization).
-- The collection is the natural handoff point between the onboarding/personalization service (writer) and the skill tree feature (reader). Using a named MongoDB collection creates a clean contract between features with no direct code coupling.
-- The `generatedAt` timestamp enables detection of "profile updated since last personalization" (see Decision 3).
-- Students without a roadmap (onboarding incomplete) receive a clear 404 response from `GET /api/skill-tree`, and the frontend routes them to the onboarding flow.
+- Feature 009 already defines roadmap generation and canonical ownership. Re-creating `student_roadmaps` in Feature 004 would duplicate source-of-truth and introduce divergence risk.
+- Consuming `GET /api/primary-roadmap` creates a clean boundary: Feature 009 writes and evolves roadmap logic; Feature 004 only reads canonical data and manages progress state.
+- The canonical payload already carries freshness metadata required by Feature 004 (`generatedAt`, `repersonalizing`), so no duplicate persistence is needed.
+- Students without a canonical roadmap (onboarding incomplete or roadmap not generated) return a clear 404-like domain error from the primary roadmap contract, and the frontend routes to onboarding.
 
 **Alternatives considered**:
+- Local `student_roadmaps` mirror inside Feature 004 — rejected because it creates dual-write/dual-read ownership and stale-read risk versus Feature 009 canonical data.
 - Static JSON files per student on the filesystem — rejected because they cannot be updated at runtime on Render; Render's ephemeral filesystem means files are lost on restart.
-- Embedding the roadmap array inside `StudentProfile` — rejected because it couples two distinct concerns: profile identity + personalized curriculum. Separate collection preserves clean module boundaries.
-- Generating roadmap on-the-fly from `StudentProfile.careerGoal + course_units` — rejected because the personalization logic is non-trivial, belongs to the onboarding/personalization feature, and would duplicate that logic here.
+- Generating roadmap on-the-fly from `StudentProfile.careerGoal + course_units` inside Feature 004 — rejected because personalization belongs to Feature 009 and would duplicate logic.
 
 ---
 
@@ -40,23 +40,37 @@ All NEEDS CLARIFICATION items from Technical Context are resolved below. No rema
 
 ---
 
-## Decision 3: Re-personalize button visibility — profile change detection
+## Decision 3: Re-personalize button visibility — canonical freshness from Feature 009
 
-**Decision**: A `needsRepersonalization` boolean flag is computed server-side on every `GET /api/skill-tree` call. The flag is `true` when `studentProfile.updatedAt > studentRoadmap.generatedAt`. When the student clicks "Re-personalize", the backend dispatches the personalization job asynchronously (same Promise-based pattern as Feature 001's roadmap trigger), updates `studentRoadmap.generatedAt` to `Date.now()`, and returns `202 Accepted`. The frontend polls `GET /api/skill-tree` every 2500ms (existing pattern from Feature 003) to detect when the new roadmap is ready.
+**Decision**: A `needsRepersonalization` boolean flag is computed server-side on every `GET /api/skill-tree` call using canonical roadmap metadata from Feature 009. The flag is `true` when `studentProfile.updatedAt > primaryRoadmap.generatedAt`. When the student clicks "Re-personalize", Feature 004 delegates regeneration to Feature 009 (async), returns `202 Accepted`, and relies on polling `GET /api/skill-tree` every 2500ms to detect completion via canonical `repersonalizing`/`generatedAt` updates.
 
 **Rationale**:
-- `StudentProfile.updatedAt` is already maintained by Feature 001 (updated on every `PUT /onboarding/draft` and on submit). `student_roadmaps.generatedAt` is set when the personalization job completes. The delta is the cheapest possible signal for "profile newer than roadmap."
-- Updating `generatedAt` to `Date.now()` on the POST request (before job completion) prevents the button from reappearing immediately on the next poll while the job is still running.
-- The polling approach reuses the existing 2500ms polling infrastructure (Feature 003) — no new SSE channel or WebSocket needed. This is consistent with the "polling only" constraint from the constitution (Render free tier, no Redis/WebSocket).
+- `StudentProfile.updatedAt` is already maintained by Feature 001, while `primaryRoadmap.generatedAt` is owned by Feature 009. Their delta is the cheapest signal for "profile newer than roadmap" without extra state.
+- Keeping `repersonalizing` ownership in Feature 009 avoids duplicate state machines across modules.
+- Polling reuses the existing 2500ms infrastructure (Feature 003) — no SSE/WebSocket required.
 
 **Alternatives considered**:
-- A separate "repersonalization status" endpoint — rejected; adds a round-trip. Including `needsRepersonalization` in the existing `GET /api/skill-tree` response is zero-cost.
-- SSE for re-personalization completion notification — rejected; no SSE channel is established for the skill tree feature; polling is sufficient for a 10s completion target.
-- Setting `generatedAt` after job completion (not before) — rejected; this would cause a brief window where the button reappears mid-job, confusing the student.
+- A separate "repersonalization status" endpoint in Feature 004 — rejected; status already belongs to canonical roadmap metadata.
+- Mirroring `generatedAt` into a local Feature 004 document — rejected; violates single source of truth.
+- SSE for completion notification — rejected; polling is sufficient for the 10s completion target.
 
 ---
 
-## Decision 4: Market Skills and Learning Resources — DB schema and ownership
+## Decision 4: Node progress canonicalization — explicit `pending` records
+
+**Decision**: `skill_node_statuses` is the canonical progress collection and must contain an explicit record for every node in the student's primary roadmap. `pending` is stored as a real persisted status, not inferred from missing documents.
+
+**Rationale**:
+- Downstream consumers require deterministic grouping by status without null/default inference.
+- Explicit records simplify analytics and contract stability (`done`/`in_progress`/`pending` counts always computed from persisted rows).
+- Re-personalization can reconcile statuses by upserting/removing records against the latest primary roadmap node set.
+
+**Alternatives considered**:
+- Implicit pending (`missing doc => pending`) — rejected due to ambiguity, extra branching in read paths, and weak downstream contracts.
+
+---
+
+## Decision 5: Market Skills and Learning Resources — DB schema and ownership
 
 **Decision**: Two read-only collections consumed by this feature:
 - `market_skills`: keyed by `courseCode`, contains an array of skill objects `{ name, jobCount }` representing industry-relevant skills associated with the course. Written by the job market crawling service (separate feature).
@@ -75,7 +89,7 @@ This feature only reads from both collections via `GET /api/skill-tree/nodes/:co
 
 ---
 
-## Decision 5: Course Resources — DB schema
+## Decision 6: Course Resources — DB schema
 
 **Decision**: New collection `course_resources` — one document per (courseCode × resourceType). Schema: `{ courseCode, type: 'textbook'|'slide'|'lab'|'assignment', title, url, description? }`. Admin-seeded. This feature's Resources tab queries `find({ courseCode })` and groups the results by `type` for display.
 
@@ -90,7 +104,7 @@ This feature only reads from both collections via `GET /api/skill-tree/nodes/:co
 
 ---
 
-## Decision 6: Frontend panel state management — three nested layers
+## Decision 7: Frontend panel state management — three nested layers
 
 **Decision**: The Zustand `skillTreeStore` has three state fields governing the panel layers:
 1. `activeCourseId: string | null` — set when a node is clicked; `null` when panel is closed.
@@ -110,7 +124,7 @@ Panel renders are gated: the course detail side panel renders only when `activeC
 
 ---
 
-## Decision 7: Graph rendering — @xyflow/react v12 (consistent with Feature 003)
+## Decision 8: Graph rendering — @xyflow/react v12 (consistent with Feature 003)
 
 **Decision**: Use `@xyflow/react` v12 (React Flow) for the skill tree graph.
 
@@ -120,14 +134,14 @@ Panel renders are gated: the course detail side panel renders only when `activeC
 - `NodeResizer` and `NodeToolbar` built-ins (v12) simplify status-change controls on nodes without custom overlay logic.
 - As a plain React library (not framework-specific), it works identically in a React 18 + React Router SPA as in any other React setup.
 - The `CourseNode` custom component pattern can be applied directly: add an `onClick` prop for panel opening, add a locked visual indicator.
-- The data source changes (from static JSON to personalized roadmap in DB), but the graph rendering layer is identical.
+- The data source changes (from static JSON to canonical primary roadmap from Feature 009), but the graph rendering layer is identical.
 
 **Alternatives considered**:
 - Switching to Cytoscape.js or D3 — no reason to change; Feature 003's decision reasoning still holds. Adding a new graph library for an existing use case would be inconsistent.
 
 ---
 
-## Decision 8: Node state enum casing — `pending`/`in_progress`/`done` (lowercase snake_case)
+## Decision 9: Node state enum casing — `pending`/`in_progress`/`done` (lowercase snake_case)
 
 **Decision**: Node states are stored as lowercase snake_case strings: `"pending"`, `"in_progress"`, `"done"`. This differs from Feature 003's PascalCase (`"Pending"`, `"InProgress"`, `"Done"`).
 

--- a/specs/004-skill-tree/spec.md
+++ b/specs/004-skill-tree/spec.md
@@ -113,6 +113,7 @@ After updating career goal, current year, or completed courses in the Settings p
 - **FR-006**: Students MUST be able to transition node states sequentially by clicking: `pending` → `in_progress` → `done`; no other transitions are permitted
 - **FR-007**: A node MUST become interactable only when ALL of its direct prerequisite nodes are in `done` state; partial prerequisite completion MUST NOT unlock a node
 - **FR-008**: All node state changes MUST be persisted server-side and survive page reloads and new sessions
+- **FR-008a**: The system MUST persist `pending` as an explicit status record in `skill_node_statuses` for every node in the student's canonical primary roadmap (no implicit `pending` from missing documents)
 - **FR-009**: When a student clicks any course node, the system MUST open a detail side panel with three tabs: Resources, Why This Course, and Market Skills
 - **FR-010**: The Resources tab MUST display course materials (textbooks, lecture slides, lab assignments, and major assignments) sourced from the application database
 - **FR-011**: The "Why This Course" tab MUST display an AI-generated explanation of why the course is relevant and necessary for the student's declared career goal, generated using course metadata and the student's goal profile
@@ -122,10 +123,11 @@ After updating career goal, current year, or completed courses in the Settings p
 - **FR-015**: Clicking the "Re-personalize" button MUST trigger re-generation of the personalized roadmap and fully re-render the skill tree with the updated node set, prerequisite ordering, and seeded states
 - **FR-016**: Each student MUST only be able to view and interact with their own skill tree; access to another student's tree MUST be prohibited
 - **FR-017**: The Skill Tree page MUST be accessible only to authenticated students; unauthenticated requests MUST be rejected
+- **FR-018**: The module MUST expose a downstream `getNodesByStatus()` contract that returns `roadmapId`, `roadmapName`, and always-present grouped arrays `done`, `inProgress`, `pending`; each item MUST include `nodeId`, `courseCode`, `courseName`, `status`, `updatedAt`
 
 ### Key Entities
 
-- **Skill Tree**: The student's complete personalized academic roadmap; scoped to one student and one career goal; contains an ordered set of course nodes derived from the personalization JSON
+- **Skill Tree**: The student's complete personalized academic roadmap; scoped to one student and one career goal; contains an ordered set of course nodes consumed from Feature 009 canonical primary roadmap
 - **Course Node**: A single UET course in the skill tree; carries a state (`pending`/`in_progress`/`done`), a locked/unlocked status computed from prerequisite states, and references to prerequisite nodes
 - **Course Resource**: A learning material item (textbook, slide deck, lab assignment, or major assignment) linked to a course node; pre-seeded by administrators
 - **Market Skill**: An industry skill (e.g., "React.js", "REST API design") associated with a course node; populated from Vietnamese IT job platform crawl data
@@ -146,10 +148,10 @@ After updating career goal, current year, or completed courses in the Settings p
 
 ## Assumptions
 
-- The personalized roadmap JSON (course nodes and prerequisite relationships filtered to the student's career goal) is provided as input by the onboarding/personalization system; this feature does not generate it
+- Feature 009 is the canonical owner of roadmap generation/storage; Feature 004 consumes the primary roadmap via `GET /api/primary-roadmap` (or equivalent internal service contract) and does not maintain a duplicate `student_roadmaps` store
 - Course resource data (textbooks, slides, lab and major assignments) is pre-seeded into the application database by administrators before students access the feature
 - Market skills data is populated and refreshed by a separate job market crawling service; this feature only consumes that data
 - AI content for the "Why This Course" tab is generated on-demand by an LLM service accessible to the backend
 - Node state transitions are strictly one-directional (`pending` → `in_progress` → `done`); reversal and skipping states are not supported
-- The personalized JSON is assumed to represent a valid DAG (no circular prerequisites); this feature does not validate graph integrity
-- Students who have not completed onboarding do not yet have a personalized roadmap and will be directed to complete onboarding before accessing the Skill Tree
+- The canonical primary roadmap payload is assumed to represent a valid DAG (no circular prerequisites); this feature does not validate graph integrity
+- Students who have not completed onboarding may not have a primary roadmap in Feature 009 and will be directed to complete onboarding before accessing the Skill Tree


### PR DESCRIPTION
Refine Feature 004 docs to remove local student_roadmaps assumptions and consume canonical roadmap data from Feature 009 via GET /api/primary-roadmap (or service-layer equivalent).

Key updates:

- spec.md: remove student_roadmaps assumption, add explicit requirement that pending must be persisted, and add downstream getNodesByStatus() contract requirements.

- plan.md: update summary, storage model, module dependencies, and test scope to include primary-roadmap adapter, explicit pending reconciliation, and grouped downstream status contract validation.

- data-model.md: replace local roadmap collection ownership with external primary roadmap contract from Feature 009; make skill_node_statuses the canonical progress store with explicit pending records; add formal getNodesByStatus() output shape (roadmapId/roadmapName + done/inProgress/pending arrays).

- contracts/rest-api.md: align endpoint notes/error semantics with primary roadmap source, explicit status persistence, repersonalization delegation to Feature 009, and add downstream service contract section for getNodesByStatus().

- research.md: revise decisions for canonical roadmap consumption, repersonalization metadata ownership, explicit pending policy, and synchronized decision indexing/terminology.