### PR TITLE
docs(007-progress-tracking): align with multi-roadmap + canonical ownership

### DIFF
--- a/specs/007-progress-tracking/contracts/rest-api.md
+++ b/specs/007-progress-tracking/contracts/rest-api.md
@@ -2,6 +2,7 @@
 
 **Feature**: `007-progress-tracking`  
 **Date**: 2026-03-11  
+**Updated**: 2026-03-14  
 **Research dependency**: [research.md](research.md) (R-002, R-004)  
 **Base URL**: `/api/progress`  
 **Auth**: All endpoints require a valid JWT Access Token in the `Authorization: Bearer <token>` header, verified by the shared `auth.middleware.js`. The SSE endpoint uses `?token=<JWT>` query param instead (see endpoint 3).
@@ -10,7 +11,7 @@
 
 ## Endpoint 1 — GET /api/progress/summaries
 
-Returns the progress summary for all roadmaps the authenticated student is enrolled in. Data is served from `roadmap_progress_cache` — no aggregation at read time.
+Returns the progress summary for all roadmap documents owned by the authenticated student (canonical ownership from Feature 009). Data is served from `roadmap_progress_cache` — no aggregation at read time.
 
 ### Request
 
@@ -29,6 +30,7 @@ No query parameters. No request body.
     {
       "roadmapId": "64f1a2b3c4d5e6f7a8b9c0d1",
       "roadmapName": "Frontend Developer",
+      "isPrimary": true,
       "totalNodes": 24,
       "doneNodes": 8,
       "inProgressNodes": 2,
@@ -39,6 +41,7 @@ No query parameters. No request body.
     {
       "roadmapId": "74f1a2b3c4d5e6f7a8b9c0d2",
       "roadmapName": "Backend Developer",
+      "isPrimary": false,
       "totalNodes": 30,
       "doneNodes": 0,
       "inProgressNodes": 0,
@@ -50,7 +53,7 @@ No query parameters. No request body.
 }
 ```
 
-**Empty state** (student has no roadmaps yet):
+**Empty state** (student owns no roadmap yet):
 
 ```json
 {
@@ -62,8 +65,9 @@ No query parameters. No request body.
 
 | Field | Type | Notes |
 |---|---|---|
-| `roadmapId` | String (ObjectId) | Identifies the roadmap — used to build deep-link URLs |
+| `roadmapId` | String (ObjectId) | Stable roadmap identifier from Feature 009 (`roadmaps._id`) |
 | `roadmapName` | String | Human-readable roadmap name |
+| `isPrimary` | Boolean | Snapshot from canonical roadmap ownership; useful for ordering/badges |
 | `totalNodes` | Number | Total course nodes on this roadmap path |
 | `doneNodes` | Number | Nodes in `done` status |
 | `inProgressNodes` | Number | Nodes in `in_progress` status |
@@ -82,7 +86,7 @@ No query parameters. No request body.
 
 ## Endpoint 2 — GET /api/progress/summaries/:roadmapId/nodes
 
-Returns every node on a specific roadmap, grouped by status. This enables the detail view (User Story 2). Data is served from the Skill Tree module via `skillTreeService.getNodesByStatus(userId, roadmapId)` — not from the cache.
+Returns every node on a specific roadmap, grouped by status. This enables the detail view (User Story 2). Data is served from Feature 004 canonical contract `skillTreeService.getNodesByStatus(userId, roadmapId)` — not from the cache.
 
 ### Request
 
@@ -105,15 +109,15 @@ Authorization: Bearer <accessToken>
   "roadmapName": "Frontend Developer",
   "nodes": {
     "done": [
-      { "nodeId": "aaa111", "nodeCode": "INT2215", "nodeName": "Lập trình" },
-      { "nodeId": "aaa112", "nodeCode": "INT2204", "nodeName": "Nhập môn lập trình" }
+      { "nodeId": "aaa111", "courseCode": "INT2215", "courseName": "Lập trình", "status": "done", "updatedAt": "2026-03-10T14:22:00.000Z" },
+      { "nodeId": "aaa112", "courseCode": "INT2204", "courseName": "Nhập môn lập trình", "status": "done", "updatedAt": "2026-03-09T09:00:00.000Z" }
     ],
     "inProgress": [
-      { "nodeId": "bbb222", "nodeCode": "INT2210", "nodeName": "Cấu trúc dữ liệu và Giải thuật" }
+      { "nodeId": "bbb222", "courseCode": "INT2210", "courseName": "Cấu trúc dữ liệu và Giải thuật", "status": "in_progress", "updatedAt": "2026-03-11T10:05:00.000Z" }
     ],
     "pending": [
-      { "nodeId": "ccc333", "nodeCode": "INT3120", "nodeName": "Lập trình Web" },
-      { "nodeId": "ccc334", "nodeCode": "INT3121", "nodeName": "Phát triển ứng dụng Web" }
+      { "nodeId": "ccc333", "courseCode": "INT3120", "courseName": "Lập trình Web", "status": "pending", "updatedAt": "2026-03-05T09:00:00.000Z" },
+      { "nodeId": "ccc334", "courseCode": "INT3121", "courseName": "Phát triển ứng dụng Web", "status": "pending", "updatedAt": "2026-03-05T09:00:00.000Z" }
     ]
   }
 }
@@ -142,16 +146,18 @@ All three keys (`done`, `inProgress`, `pending`) are always present — never om
 | `nodes.done` | Array | Nodes in `done` status |
 | `nodes.inProgress` | Array | Nodes in `in_progress` status |
 | `nodes.pending` | Array | Nodes in `pending` status (locked + actionable, not distinguished here — locked state is a Skill Tree concern) |
-| `nodes.*.nodeId` | String (ObjectId) | Used to build the Skill Tree deep-link URL |
-| `nodes.*.nodeCode` | String | Course code, e.g. `INT2215` |
-| `nodes.*.nodeName` | String | Course display name |
+| `nodes.*.nodeId` | String | Used to build the Skill Tree deep-link URL |
+| `nodes.*.courseCode` | String | Course code, e.g. `INT2215` |
+| `nodes.*.courseName` | String | Course display name |
+| `nodes.*.status` | String | `done` / `in_progress` / `pending` |
+| `nodes.*.updatedAt` | String (ISO 8601) | Last status update timestamp |
 
 ### Error responses
 
 | Status | Condition |
 |---|---|
 | `401 Unauthorized` | Missing or expired access token |
-| `403 Forbidden` | Authenticated student is not enrolled in this `roadmapId` |
+| `403 Forbidden` | Authenticated student does not own this `roadmapId` |
 | `404 Not Found` | `roadmapId` does not exist |
 | `500 Internal Server Error` | Unexpected DB or service failure |
 
@@ -190,7 +196,7 @@ Fired after each successful cache refresh. Payload is the updated summary for th
 
 ```
 event: progress:update
-data: {"roadmapId":"64f1a2b3c4d5e6f7a8b9c0d1","roadmapName":"Frontend Developer","totalNodes":24,"doneNodes":9,"inProgressNodes":2,"pendingNodes":13,"progressPercent":38,"lastActivityDate":"2026-03-11T10:05:00.000Z"}
+data: {"roadmapId":"64f1a2b3c4d5e6f7a8b9c0d1","roadmapName":"Frontend Developer","isPrimary":true,"totalNodes":24,"doneNodes":9,"inProgressNodes":2,"pendingNodes":13,"progressPercent":38,"lastActivityDate":"2026-03-11T10:05:00.000Z"}
 
 ```
 
@@ -241,7 +247,11 @@ When a student taps a node in the detail view, the frontend navigates to:
 /skill-tree/:roadmapId?focus=<nodeId>
 ```
 
-- `:roadmapId` — the `roadmapId` from the current detail view.
+- `:roadmapId` — stable roadmap `_id` from Feature 009.
 - `focus=<nodeId>` — the `nodeId` of the tapped node.
 - The Skill Tree page reads `useSearchParams()` and scrolls/highlights the node matching `focus`.
 - This is a React Router client-side navigation — no backend endpoint. The Skill Tree feature is responsible for reading and honoring the `focus` param.
+
+### Consistency policy note
+
+`refreshCache` failures are treated as soft-fail events because cache is derived data. Skill Tree user action is not failed; cache repair is retried asynchronously (eventual consistency). During repair window, `GET /api/progress/summaries` may return briefly stale values.

--- a/specs/007-progress-tracking/data-model.md
+++ b/specs/007-progress-tracking/data-model.md
@@ -2,6 +2,7 @@
 
 **Feature**: `007-progress-tracking`  
 **Date**: 2026-03-11  
+**Updated**: 2026-03-14  
 **Research dependency**: [research.md](research.md) (R-003, R-005)
 
 ---
@@ -10,7 +11,9 @@
 
 **MongoDB collection**: `roadmap_progress_cache`
 
-**Purpose**: Pre-computed progress summary for one (student, roadmap) pair. This is the sole collection owned by the Progress Tracking feature. It is written exclusively by `progress.service.js#refreshCache` (called from the Skill Tree module after every node status change) and read by the Progress Dashboard endpoints. It is never written by the API handlers — the REST layer is read-only.
+**Purpose**: Pre-computed progress summary for one `(student, roadmap)` pair. This is the sole collection owned by Progress Tracking. It is written exclusively by `progress.service.js#refreshCache` (triggered by Skill Tree after node-status writes) and read by dashboard endpoints. It is never written by REST handlers.
+
+**Cardinality (multi-roadmap)**: For each `userId`, cardinality is `0..N` cache docs where `N` equals count of owned roadmap documents returned by Feature 009 in dashboard scope. Exactly one cache document exists per unique `(userId, roadmapId)`.
 
 ### Schema
 
@@ -18,7 +21,9 @@
 |---|---|---|---|---|---|
 | `_id` | ObjectId | auto | — | — | MongoDB primary key |
 | `userId` | ObjectId | yes | — | ref: `users`; part of compound unique key | FK to authenticated student |
-| `roadmapId` | ObjectId | yes | — | ref: `roadmaps` (Skill Tree); part of compound unique key | FK to the student's roadmap |
+| `roadmapId` | ObjectId | yes | — | ref: `roadmaps` (Feature 009); part of compound unique key | Stable roadmap key from 009 canonical owner |
+| `roadmapName` | String | yes | — | Non-empty | Display name snapshot for dashboard cards |
+| `isPrimary` | Boolean | yes | `false` | Non-unique | Snapshot hint from 009 for frontend sort/display |
 | `totalNodes` | Number | yes | — | Integer ≥ 0 | Total course nodes on the roadmap path |
 | `doneNodes` | Number | yes | — | Integer ≥ 0; ≤ `totalNodes` | Count of nodes in `done` status |
 | `inProgressNodes` | Number | yes | — | Integer ≥ 0; ≤ `totalNodes` | Count of nodes in `in_progress` status |
@@ -34,7 +39,8 @@
 |---|---|---|---|
 | `_id` (default) | `_id` | Unique | MongoDB default |
 | `userId_roadmapId_unique` | `userId: 1, roadmapId: 1` | **Unique compound** | One cache document per (student, roadmap) pair; upsert filter key |
-| `userId_idx` | `userId: 1` | Standard | Fast `find({ userId })` for the dashboard's overview query |
+| `userId_updatedAt_idx` | `userId: 1, updatedAt: -1` | Standard compound | Fast dashboard listing by user + recency sort |
+| `userId_isPrimary_updatedAt_idx` | `userId: 1, isPrimary: -1, updatedAt: -1` | Standard compound | Optional sort path: primary first, then recent |
 
 ### Write path (via `progress.service.js#refreshCache`)
 
@@ -43,13 +49,16 @@ Skill Tree updateNodeStatus()
     │
     │  await progressService.refreshCache(userId, roadmapId)
     ▼
-RoadmapNode.aggregate([ $match{userId, roadmapId}, $group{totalNodes, doneNodes, inProgressNodes} ])
+skillTreeService.getNodesByStatus(userId, roadmapId)
+       │   returns { roadmapId, roadmapName, done[], inProgress[], pending[] }
+       │   backed by Feature 004 `skill_node_statuses`
     │
-    │  One round trip to Atlas — atomic snapshot
+       │  In-process computation from canonical grouped payload
     ▼
 RoadmapProgressCache.findOneAndUpdate(
   { userId, roadmapId },                          ← filter (hits compound unique index)
-  { $set: { totalNodes, doneNodes, inProgressNodes, pendingNodes,
+       { $set: { roadmapName, isPrimary,
+                                          totalNodes, doneNodes, inProgressNodes, pendingNodes,
             progressPercent, lastActivityDate, updatedAt },
     $setOnInsert: { createdAt } },
   { upsert: true, new: true }
@@ -57,6 +66,8 @@ RoadmapProgressCache.findOneAndUpdate(
     │
     ▼
 progressSse.notifyUser(userId, updatedSummary)     ← fire-and-forget SSE push
+
+On refresh error: log + schedule retry (eventual consistency), do not fail already-committed Skill Tree action.
 ```
 
 ### `progressPercent` computation rule
@@ -71,26 +82,23 @@ This is the same formula as the Skill Tree progress bar (SC-002 consistency guar
 
 ---
 
-## Referenced Entity: RoadmapNode (read-only, owned by Feature 004 — Skill Tree)
+## Referenced Entity: SkillNodeStatus (read-only, owned by Feature 004 — Skill Tree)
 
-**MongoDB collection**: `roadmap_nodes` *(working name — Skill Tree's planner may rename)*
+**MongoDB collection**: `skill_node_statuses`
 
-**Purpose**: Per-student node status records. The `$group` aggregation in `refreshCache` runs against this collection. Progress Tracking MUST NOT write to it.
+**Purpose**: Canonical node status store (`pending` | `in_progress` | `done`) for Skill Tree. Progress Tracking MUST NOT read this collection directly in normal flow; it consumes Feature 004 service contract `getNodesByStatus(userId, roadmapId)`.
 
-### Minimum fields required by Progress Tracking
+### Contract fields required by Progress Tracking
 
 | Field | Type | Notes |
 |---|---|---|
-| `userId` | ObjectId | Part of compound index `{ userId, roadmapId }` |
-| `roadmapId` | ObjectId | Part of compound index `{ userId, roadmapId }` |
-| `nodeId` | ObjectId | ref: `course_units._id` |
-| `nodeName` | String | Display name; returned by `getNodesByStatus()` for the detail view |
-| `nodeCode` | String | Course code (e.g., `INT2215`); used as a stable key in the deep-link |
+| `nodeId` | String | Stable node identifier in roadmap payload |
+| `courseCode` | String | Course code (e.g., `INT2215`) |
+| `courseName` | String | Display name for detail view |
 | `status` | String (enum) | `"pending"` \| `"in_progress"` \| `"done"` |
+| `updatedAt` | Date | Last status mutation timestamp |
 
-**Compound index required**: `{ userId: 1, roadmapId: 1 }` — must be present for the `$group` aggregation to stay within Atlas M0 scan limits.
-
-> **Note to Skill Tree planner**: Progress Tracking depends on the above field names and index. If the actual schema differs, update the `$match` in `progress.service.js#_computeStats` accordingly and document the change in Skill Tree's `data-model.md`.
+`getNodesByStatus(userId, roadmapId)` MUST always return all three arrays (`done`, `inProgress`, `pending`) even when empty.
 
 ---
 
@@ -102,11 +110,11 @@ This is the same formula as the Skill Tree progress bar (SC-002 consistency guar
 
 ---
 
-## Referenced Entity: Roadmap (read-only, owned by Feature 001 — Onboarding / Feature 004 — Skill Tree)
+## Referenced Entity: Roadmap (read-only, owned by Feature 009 — Roadmap Generator)
 
-**MongoDB collection**: `roadmaps` *(to be confirmed by Skill Tree planner)*
+**MongoDB collection**: `roadmaps`
 
-**Purpose**: `roadmapId` and `roadmapName` are needed to populate the dashboard cards. Progress Tracking reads `roadmapId` and `roadmapName` from the Skill Tree module's `getNodesByStatus()` / `getAllRoadmaps(userId)` service function — it does NOT query the `roadmaps` collection directly.
+**Purpose**: Canonical ownership + identity source. Progress Tracking uses 009 service/API contract to resolve which roadmaps the student owns and uses `_id` as stable `roadmapId`.
 
 ---
 
@@ -117,14 +125,16 @@ Student updates node on Skill Tree
          │
          ▼
   skillTree.service.js#updateNodeStatus(userId, roadmapId, nodeId, newStatus)
-         │   writes node status to roadmap_nodes
+         │   writes node status to skill_node_statuses
          │
          │   await progressService.refreshCache(userId, roadmapId)
          ▼
   progress.service.js#refreshCache
-         │   reads roadmap_nodes → $group aggregation
+         │   calls skillTreeService.getNodesByStatus(userId, roadmapId)
+         │   computes counts in-process
          │   upserts roadmap_progress_cache
          │   fire-and-forget: progressSse.notifyUser(userId, summary)
+         │   on error: soft-fail + eventual-consistency retry
          ▼
   Progress Dashboard (open tab)
          │   receives SSE event: progress:update

--- a/specs/007-progress-tracking/plan.md
+++ b/specs/007-progress-tracking/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-A read-only Progress Dashboard page (`/progress`) that gives students a cross-roadmap overview of their learning progress — the one view Skill Tree does not provide because it displays only one roadmap at a time. Progress data is served from a pre-computed `roadmap_progress_cache` MongoDB collection (one document per student+roadmap pair). The cache is refreshed synchronously by the Skill Tree module via a service-layer call after every node status write — no queue, no Redis. Real-time dashboard updates are delivered to open tabs via a dedicated SSE channel (`GET /api/progress/sse`), following the same Map-based connection store pattern established in Feature 001. Node-level drill-down queries node status data from the Skill Tree module through the service layer. No new npm packages are required.
+A read-only Progress Dashboard page (`/progress`) that gives students a cross-roadmap overview of their learning progress across all roadmap documents they own (Feature 009 canonical ownership). Progress data is served from a pre-computed `roadmap_progress_cache` MongoDB collection (one document per student+roadmap pair, keyed by stable 009 `roadmapId`). The cache is refreshed by Skill Tree via service-layer call after node-status writes, using **soft-fail + eventual consistency** policy (no user action rollback on cache failures). Real-time dashboard updates are delivered via dedicated SSE channel (`GET /api/progress/sse`). Node-level drill-down uses Feature 004 canonical contract `getNodesByStatus(userId, roadmapId)` backed by `skill_node_statuses`. No new npm packages are required.
 
 ## Technical Context
 
@@ -14,23 +14,23 @@ A read-only Progress Dashboard page (`/progress`) that gives students a cross-ro
 - Backend: `express.js`, `mongoose 8` — no new packages; reuses existing stack
 - Frontend: `React 18`, `React Router v6`, native `EventSource` (SSE client — pattern reused from Feature 001)
 
-**Storage**: MongoDB Atlas free tier — new `roadmap_progress_cache` collection (owned by this feature); reads `roadmap_nodes` collection (owned by Feature 004 — Skill Tree)
+**Storage**: MongoDB Atlas free tier — new `roadmap_progress_cache` collection (owned by this feature); reads roadmap ownership from Feature 009 (`roadmaps` via service contract) and node statuses from Feature 004 contract (`getNodesByStatus`, backed by `skill_node_statuses`)
 **Testing**: Jest 29 — unit tests only; MongoDB mocked via `jest.fn()`; no external services required
 **Target Platform**: Backend → Render (Node.js web service, free tier); Frontend → Vercel (React SPA)
 **Project Type**: Web application — React SPA + Node.js/Express REST API (modular monolith)
 **Performance Goals**: Dashboard `GET /api/progress/summaries` served from pre-computed cache → single `find({ userId })` → p95 < 100ms; SC-001 (< 2s on 4G) met by cache design. SSE push within 200ms of node write on Atlas M0; SC-004 (< 5s) met comfortably.
-**Constraints**: No Redis — cache stored in MongoDB; read-only REST API (no write endpoints in this module); SSE auth via `?token=<JWT>` query param (EventSource cannot send headers); soft-fail on `refreshCache` errors (node write already committed); no new npm packages introduced
-**Scale/Scope**: UET-VNU students only; up to 10 roadmaps per student (per SC-001); tens to low hundreds of nodes per roadmap
+**Constraints**: No Redis — cache stored in MongoDB; read-only REST API (no write endpoints in this module); SSE auth via `?token=<JWT>` query param (EventSource cannot send headers); `refreshCache` soft-fail + eventual-consistency retry/repair; no new npm packages introduced
+**Scale/Scope**: UET-VNU students only; multi-roadmap ownership from Feature 009 (typically up to 10 completed roadmaps in dashboard scope); tens to low hundreds of nodes per roadmap
 
 ## Constitution Check
 
 *Pre-design gate — re-checked after Phase 1 design: all items pass.*
 
-- [x] **Modular Monolithic**: All progress logic is isolated in `backend/src/modules/progress/`. The only cross-module interaction is (a) Skill Tree service calls `progressService.refreshCache()` via service-layer injection — no direct cross-module import, and (b) `progress.service.js#getRoadmapDetail` calls `skillTreeService.getNodesByStatus()` through the service layer. No microservice split introduced.
+- [x] **Modular Monolithic**: All progress logic is isolated in `backend/src/modules/progress/`. Cross-module interaction is service-layer only: (a) Skill Tree calls `progressService.refreshCache()` after status write, (b) progress reads node-group payload via `skillTreeService.getNodesByStatus()`, and (c) progress resolves owned roadmap identities via Feature 009 roadmap service contract. No direct cross-module model import. No microservice split introduced.
 - [x] **UET-First**: Dashboard is exclusively for UET-VNU students. No abstraction for other institutions. Career goal and roadmap concepts are UET-specific, hardcoded in scope.
 - [x] **Privacy**: `roadmap_progress_cache` stores only aggregate counts and timestamps — no academic credentials, no grades, no UET portal data. This is the minimum data needed for the dashboard. Fully consistent with Principle III.
 - [x] **AI-Assisted**: No Gemini API calls in this feature. All computation (progress percent formula, node grouping) is pure code logic. No LLM involved.
-- [x] **Test What Matters**: Unit tests mandatory for `progress.service.js` — the `refreshCache` formula (including division-by-zero guard for `totalNodes = 0`), `getAll` (empty array when no cache docs), and `getRoadmapDetail` (correct status grouping). These are the complex pieces with side effects or business logic.
+- [x] **Test What Matters**: Unit tests mandatory for `progress.service.js` — `refreshCache` formula (including division-by-zero guard), soft-fail + eventual-retry scheduling behavior, `getAll` (empty array when no cache docs), and `getRoadmapDetail` (correct 004 status grouping shape). These are the complex pieces with side effects or business logic.
 
 ## Project Structure
 
@@ -57,6 +57,7 @@ backend/
 │   │   ├── progress/
 │   │   │   ├── roadmapProgressCache.model.js  # Mongoose schema: roadmap_progress_cache collection
 │   │   │   ├── progress.service.js            # getAll(userId), getRoadmapDetail(userId, roadmapId), refreshCache(userId, roadmapId)
+│   │   │   ├── roadmapOwner.adapter.js        # Feature 009 adapter: list owned roadmaps + stable roadmapId mapping
 │   │   │   ├── progress.controller.js         # Express handlers — thin, delegates to service
 │   │   │   ├── progress.routes.js             # GET /api/progress/summaries, /summaries/:id/nodes, /sse
 │   │   │   └── progress.sse.js                # Map-based SSE store: addClient, removeClient, notifyUser
@@ -67,7 +68,7 @@ backend/
 └── tests/
     └── unit/
         └── progress/
-            └── progress.service.test.js        # refreshCache formula + edge cases, getAll, getRoadmapDetail grouping
+            └── progress.service.test.js        # refreshCache formula + soft-fail/eventual consistency + getAll + getRoadmapDetail grouping
 
 frontend/
 ├── src/
@@ -83,7 +84,7 @@ frontend/
 │       └── AuthGuard.jsx                       # Shared — wraps /progress route (no changes needed)
 ```
 
-**Structure Decision**: Option 2 — Web application. Modular monolith backend with progress logic isolated in `modules/progress/`. SSE store follows the established per-feature Map pattern (`progress.sse.js`). Frontend uses feature-folder structure mirroring the backend module boundary. No new top-level directories introduced. Cross-module communication goes exclusively through service-layer function calls.
+**Structure Decision**: Option 2 — Web application. Modular monolith backend with progress logic isolated in `modules/progress/`. SSE store follows established per-feature Map pattern (`progress.sse.js`). Frontend uses feature-folder structure mirroring backend boundary. Cross-module communication goes exclusively through service-layer contracts with Feature 004 (node statuses) and Feature 009 (roadmap ownership + stable IDs).
 
 ## Complexity Tracking
 

--- a/specs/007-progress-tracking/research.md
+++ b/specs/007-progress-tracking/research.md
@@ -2,6 +2,7 @@
 
 **Feature**: `007-progress-tracking`  
 **Date**: 2026-03-11  
+**Updated**: 2026-03-14  
 **Feeds into**: [plan.md](plan.md), [data-model.md](data-model.md), [contracts/rest-api.md](contracts/rest-api.md)
 
 ---
@@ -10,12 +11,13 @@
 
 **Question**: In a monolith with no queue and no cross-module direct imports, how does the Skill Tree module cause the Progress cache to refresh after a node status write?
 
-**Decision**: Sequential `await` via service-layer dependency injection. The Skill Tree service receives a `progressService` reference at bootstrap and calls `await progressService.refreshCache(userId, roadmapId)` directly after the node write commits. If `refreshCache` throws, Skill Tree soft-fails (logs the error, does not re-throw) — because the node write has already committed and returning HTTP 500 to the student would be misleading.
+**Decision**: Sequential `await` via service-layer dependency injection. Skill Tree calls `await progressService.refreshCache(userId, roadmapId)` right after status write commit. If `refreshCache` throws, Skill Tree **soft-fails** (log only, do not re-throw) and Progress module schedules asynchronous retry for eventual consistency.
 
 **Rationale**:
 - Fire-and-forget (un-awaited Promise) gives no delivery guarantee on a busy event loop. The 5-second SSE update window (SC-004) requires the call to be awaited.
 - The call is pure in-process — no network hop, no queue latency. End-to-end latency from node write commit → cache upsert → SSE push is estimated at 50–200ms on MongoDB Atlas M0 free tier.
-- Soft-fail is correct because the `roadmap_progress_cache` document is derived data. Stale cache is a degraded-but-safe state; a spurious 500 to the student is a worse failure mode.
+- Soft-fail is correct because `roadmap_progress_cache` is derived data. Stale cache is degraded-but-safe; a spurious 500 to the student is worse.
+- Eventual consistency retry (in-process retry queue with bounded backoff) repairs transient Mongo failures without queue infrastructure.
 
 **Alternatives considered**:
 - MongoDB Change Streams: Not available on Atlas M0 free tier. Rejected.
@@ -48,31 +50,27 @@
 
 ## R-003: Cache Computation — aggregation pipeline vs. multiple `countDocuments` calls?
 
-**Question**: When `refreshCache(userId, roadmapId)` runs, should it compute `totalNodes`, `doneNodes`, `inProgressNodes` via one `$group` aggregation or three separate `countDocuments` calls?
+**Question**: With Feature 004 now canonical for node status (`skill_node_statuses` + `getNodesByStatus`), should Progress compute counts by querying Mongo directly or by consuming the 004 grouped contract?
 
-**Decision**: Single `$group` aggregation pipeline with conditional `$sum` operators.
+**Decision**: Consume `skillTreeService.getNodesByStatus(userId, roadmapId)` and compute summary counts in-process from returned arrays.
 
 ```js
-const [result] = await RoadmapNode.aggregate([
-  { $match: { userId, roadmapId } },
-  {
-    $group: {
-      _id: null,
-      totalNodes:       { $sum: 1 },
-      doneNodes:        { $sum: { $cond: [{ $eq: ['$status', 'done'] },        1, 0] } },
-      inProgressNodes:  { $sum: { $cond: [{ $eq: ['$status', 'in_progress'] }, 1, 0] } },
-    }
-  }
-]);
+const detail = await skillTreeService.getNodesByStatus(userId, roadmapId);
+
+const doneNodes = detail.done.length;
+const inProgressNodes = detail.inProgress.length;
+const pendingNodes = detail.pending.length;
+const totalNodes = doneNodes + inProgressNodes + pendingNodes;
 ```
 
 **Rationale**:
-- Three `countDocuments` calls = 3 round trips to Atlas M0. Each trip adds 20–60ms; total 60–180ms. Worse, the three counts are not from the same logical snapshot — a concurrent write between call 2 and call 3 produces a corrupted cache document.
-- A single aggregation is one atomic read, one round trip, consistent counts. On Atlas M0, this runs in 5–20ms for the expected data volume (tens to low hundreds of nodes per student per roadmap).
+- Removes schema coupling from Progress to internal 004 persistence details.
+- Reuses already-standardized 004 status grouping payload used by detail endpoint.
+- Keeps ownership boundaries strict: 004 owns status semantics; 007 owns aggregate cache.
 
 **Alternatives considered**:
-- `countDocuments` × 3: Simpler to read but not atomic, more round trips. Rejected.
-- Pre-counting with embedded counters in a `roadmaps` document: Requires counter synchronization logic everywhere Skill Tree updates a node. More complexity for no benefit. Rejected.
+- Direct query on `skill_node_statuses` from Progress: tighter coupling and duplicated grouping logic. Rejected.
+- Embedded counters in `roadmaps`: introduces write-time coupling into 009 canonical owner. Rejected.
 
 ---
 
@@ -95,14 +93,29 @@ const [result] = await RoadmapNode.aggregate([
 
 ## R-005: Skill Tree Node Storage Schema — what does `refreshCache` read from?
 
-**Question**: Feature 004 (Skill Tree) has not been planned yet. What shape of data does `refreshCache` need from the Skill Tree module, and how should this dependency be declared?
+**Question**: What exact 004 contract does Progress depend on after introducing canonical roadmap ownership in 009?
 
-**Decision**: Progress Tracking declares a **forward-compatible interface contract** with the Skill Tree module. The contract is:
+**Decision**: Progress Tracking depends on two canonical contracts:
 
-1. The Skill Tree module MUST maintain a MongoDB collection (working name: `roadmap_nodes`) with at minimum the following fields per document: `userId` (ObjectId), `roadmapId` (ObjectId), `status` (String enum: `"pending"` | `"in_progress"` | `"done"`). A compound index on `{ userId: 1, roadmapId: 1 }` MUST exist for aggregation performance.
-2. The Skill Tree module MUST expose a service function `getNodesByStatus(userId, roadmapId)` that returns `{ done: [...], inProgress: [...], pending: [...] }` — each entry with `nodeId`, `nodeCode`, `nodeName` fields. The Progress module calls this for the `/nodes` detail endpoint.
-3. The Skill Tree module MUST call `progressService.refreshCache(userId, roadmapId)` from its `updateNodeStatus` service function, after the node write commits.
+1. **Feature 004 contract**: `getNodesByStatus(userId, roadmapId)` returns `{ roadmapId, roadmapName, done[], inProgress[], pending[] }` with node entries `{ nodeId, courseCode, courseName, status, updatedAt }`, backed by `skill_node_statuses`.
+2. **Feature 009 contract**: roadmap ownership and stable identity come from 009 `roadmaps._id`; Progress treats this as authoritative `roadmapId`.
+3. **Trigger contract**: Skill Tree calls `progressService.refreshCache(userId, roadmapId)` after node-status commit.
 
-**Rationale**: Documenting the contract here locks in the interface before Skill Tree planning begins, preventing a design mismatch. Skill Tree's plan can accommodate this contract as an explicit integration requirement.
+**Rationale**: This preserves canonical ownership boundaries: 009 owns roadmap lifecycle/identity, 004 owns node status state machine, 007 owns derived aggregation and dashboard read model.
 
-**Note for Skill Tree planner**: The `roadmap_nodes` collection name is a working assumption. Skill Tree may use a different name or embed nodes inside a `roadmaps` document — what matters is that `progressService.refreshCache` can run the `$group` aggregation against whichever collection Skill Tree uses, and that `getNodesByStatus(userId, roadmapId)` is exposed as a service function.
+---
+
+## R-006: Multi-roadmap source of truth — enrolled roadmaps vs owned roadmaps
+
+**Question**: Should dashboard scope use legacy onboarding enrollment mapping or canonical roadmap ownership from Feature 009?
+
+**Decision**: Use Feature 009 canonical ownership only. Dashboard list is all owned roadmap documents in dashboard scope (typically `status=completed`).
+
+**Rationale**:
+- 009 is explicit canonical owner of roadmap lifecycle and identity.
+- Ownership semantics remain correct even with roadmap history/variants and primary switching.
+- Avoids cross-feature drift where enrollment view differs from actual roadmap documents.
+
+**Alternatives considered**:
+- Onboarding-based enrollment list: legacy assumption, not canonical after 009. Rejected.
+- Skill Tree primary-only scope: fails multi-roadmap requirement. Rejected.

--- a/specs/007-progress-tracking/spec.md
+++ b/specs/007-progress-tracking/spec.md
@@ -2,6 +2,7 @@
 
 **Feature Branch**: `007-progress-tracking`  
 **Created**: 2026-03-11  
+**Updated**: 2026-03-14  
 **Status**: Draft  
 **Input**: User description: "Xây dựng tính năng Theo dõi Tiến độ Học tập (Progress Tracking) cho UETCompass, cho phép sinh viên giám sát tiến độ học tập của mình trên các roadmap đang theo học. Tính năng này bổ sung cho feature Skill Tree — không thay thế hay tái xây dựng bất kỳ phần nào của nó."
 
@@ -10,6 +11,11 @@
 ## Context & Scope
 
 Progress Tracking adds a dedicated **Progress Dashboard** (`/progress`) that gives students a cross-roadmap view of their learning progress — the one thing Skill Tree does not provide because it displays only one roadmap at a time.
+
+Feature boundary alignment:
+- Roadmap lifecycle and ownership are canonical in Feature 009.
+- `roadmapId` is the stable identifier from Feature 009 (`roadmaps._id`).
+- Progress detail contract is consumed from Feature 004 (`getNodesByStatus`) backed by `skill_node_statuses`.
 
 **What this feature does NOT do:**
 - Does not display the interactive tree visualization (that is Skill Tree's responsibility).
@@ -23,15 +29,15 @@ Progress Tracking adds a dedicated **Progress Dashboard** (`/progress`) that giv
 
 ### User Story 1 – View Multi-Roadmap Progress Overview (Priority: P1)
 
-A student who is enrolled in more than one roadmap opens the Progress Dashboard and immediately sees a summary card for each roadmap, showing how far along they are on each path. At a glance, they can tell which roadmap they are most advanced on, which has the most recent activity, and which still needs attention — without having to navigate to each Skill Tree individually.
+A student who owns more than one roadmap opens the Progress Dashboard and immediately sees a summary card for each owned roadmap, showing how far along they are on each path. At a glance, they can tell which roadmap they are most advanced on, which has the most recent activity, and which still needs attention — without having to navigate to each Skill Tree individually.
 
 **Why this priority**: This is the core value proposition of the entire feature. Without the cross-roadmap overview, the dashboard provides no benefit over simply using each Skill Tree separately. Every other user story builds on top of this one.
 
-**Independent Test**: Can be fully tested by logging in as a student with two or more active roadmaps, navigating to `/progress`, and verifying that all enrolled roadmaps appear as separate cards, each showing a correct completion percentage, node counts by status, and last activity date.
+**Independent Test**: Can be fully tested by logging in as a student with two or more owned roadmap documents, navigating to `/progress`, and verifying that all owned roadmaps appear as separate cards, each showing a correct completion percentage, node counts by status, and last activity date.
 
 **Acceptance Scenarios**:
 
-1. **Given** a student is enrolled in 3 roadmaps, **When** they open the Progress Dashboard, **Then** all 3 roadmaps are displayed — one card each — with no roadmap omitted.
+1. **Given** a student owns 3 roadmaps, **When** they open the Progress Dashboard, **Then** all 3 roadmaps are displayed — one card each — with no roadmap omitted.
 2. **Given** a roadmap card is displayed, **When** the student inspects it, **Then** they see the roadmap name, completion percentage (Done ÷ total nodes × 100%), count of Done nodes out of total, and the date of the most recent node-status change on that roadmap.
 3. **Given** a student has marked different nodes on different roadmaps, **When** viewing the dashboard, **Then** each card independently reflects its own roadmap's data — cards do not share or mix data.
 4. **Given** a student's roadmap has 0 nodes Done and 0 nodes In Progress, **When** its card is shown, **Then** it displays 0% completion and a "Not started" indication rather than an error or missing value.
@@ -41,7 +47,7 @@ A student who is enrolled in more than one roadmap opens the Progress Dashboard 
 
 ### User Story 2 – Drill Down Into a Roadmap's Node-Level Detail (Priority: P1)
 
-After seeing the overview, a student selects one roadmap card and is shown a detailed breakdown of every node on that roadmap, organized into three groups: Done, In Progress, and Pending. They can see exactly which courses they have completed, which they are currently working on, and which still lie ahead — all without switching to the Skill Tree.
+After seeing the overview, a student selects one roadmap card and is shown a detailed breakdown of every node on that roadmap, organized into three groups: Done, In Progress, and Pending. They can see exactly which courses they have completed, which they are currently working on, and which still lie ahead — all without switching to the Skill Tree. This detail payload follows Feature 004 `getNodesByStatus(userId, roadmapId)`.
 
 **Why this priority**: The overview cards tell the "how much" story; the detail view tells the "what exactly" story. Together, they satisfy a student's complete diagnostic question: "Where exactly am I on each of my paths?" This story adds the depth needed to make the dashboard truly useful.
 
@@ -87,13 +93,14 @@ A student has the Progress Dashboard open in one browser tab and the Skill Tree 
 1. **Given** the dashboard is open and a student marks a node Done on the Skill Tree in another tab, **When** they switch back to the Dashboard, **Then** the affected roadmap card updates its percentage and node counts within 5 seconds — without a manual page reload.
 2. **Given** a roadmap had a last activity date of yesterday, **When** a node is updated today, **Then** the "last activity" date on that roadmap's card updates to today.
 3. **Given** a student marks multiple nodes in quick succession on the Skill Tree, **When** they return to the dashboard, **Then** all changes are reflected correctly — no intermediate states are displayed.
+4. **Given** the node write succeeds but cache refresh fails, **When** Skill Tree responds to the student action, **Then** the action still succeeds and Progress cache is repaired by eventual-consistency retry.
 
 ---
 
 ### Edge Cases
 
-- **No roadmaps enrolled**: A student who has not completed onboarding (no roadmap assigned yet) opens `/progress` → the dashboard shows an empty state with a prompt directing them to complete onboarding, not an error page.
-- **Single roadmap**: A student enrolled in exactly one roadmap opens `/progress` → the dashboard shows that single roadmap's summary and allows access to its detail view; the experience is consistent with the multi-roadmap view.
+- **No roadmaps owned**: A student with no owned roadmap document in Feature 009 opens `/progress` → the dashboard shows an empty state, not an error page.
+- **Single roadmap**: A student owning exactly one roadmap opens `/progress` → the dashboard shows that single roadmap's summary and allows access to its detail view; the experience is consistent with the multi-roadmap view.
 - **All nodes Pending / 0% progress**: A student who has just started a roadmap and changed no statuses → the dashboard displays 0% and an empty Done group without errors.
 - **100% completion**: A student who has marked every node Done → the dashboard shows 100% and an empty Pending and In Progress group, with a visual completion signal.
 - **Very large roadmap (100+ nodes)**: A student with a roadmap containing 100+ nodes → the detail view loads completely within the dashboard's performance budget; nodes are presented in a scannable format (e.g., grouped, scrollable) rather than a flat dump.
@@ -106,29 +113,33 @@ A student has the Progress Dashboard open in one browser tab and the Skill Tree 
 ### Functional Requirements
 
 - **FR-001**: The system MUST display a dedicated Progress Dashboard at a fixed, predictable URL accessible from the main navigation.
-- **FR-002**: The dashboard MUST show one summary card per roadmap the student is enrolled in, covering all roadmaps without exception.
+- **FR-002**: The dashboard MUST show one summary card per roadmap document owned by the authenticated student (canonical ownership from Feature 009), covering all owned roadmaps without exception.
 - **FR-003**: Each summary card MUST display: (a) the roadmap name, (b) the completion percentage calculated as Done nodes ÷ total nodes × 100% (rounded to the nearest whole number), (c) the count of nodes in each of the three states (Done, In Progress, Pending), and (d) the date of the most recent node-status change on that roadmap.
 - **FR-004**: The dashboard MUST be read-only — it MUST NOT provide any control to change a node's status.
 - **FR-005**: A student MUST be able to select a roadmap card to open a detail view listing every node in that roadmap, organized into three labeled groups: Done, In Progress, and Pending.
 - **FR-006**: Every node in the detail view MUST be tappable/clickable, and the action MUST navigate the student to the Skill Tree page for that roadmap with the selected node visually highlighted or scrolled into view.
 - **FR-007**: The completion percentage shown on the dashboard MUST use the same formula as the Skill Tree progress bar (Done ÷ total nodes × 100%), ensuring both views always display the same value.
 - **FR-008**: The dashboard MUST reflect node-status changes made on the Skill Tree within 5 seconds, without requiring the student to manually reload the page.
-- **FR-009**: The dashboard MUST display an empty state (not an error) for students who have no enrolled roadmaps, with guidance pointing them toward completing onboarding.
+- **FR-009**: The dashboard MUST display an empty state (not an error) for students who have no owned roadmaps.
 - **FR-010**: When a status group in the detail view contains zero nodes, the system MUST show a clear empty-state indication for that group rather than hiding it silently or displaying a blank section.
+- **FR-011**: The feature MUST use stable `roadmapId` from Feature 009 (`roadmaps._id`) as cache key, API path key, SSE merge key, and deep-link key.
+- **FR-012**: The node-detail endpoint MUST use Feature 004 canonical service contract `getNodesByStatus(userId, roadmapId)` backed by `skill_node_statuses`.
+- **FR-013**: `refreshCache` policy MUST be **soft-fail + eventual consistency**: refresh failures MUST NOT fail student node-update actions; retry/repair occurs asynchronously.
 
 ### Key Entities
 
-- **Progress Dashboard**: The cross-roadmap overview page accessible at a fixed URL. Displays one summary card per enrolled roadmap. Read-only.
+- **Progress Dashboard**: The cross-roadmap overview page accessible at a fixed URL. Displays one summary card per owned roadmap. Read-only.
 - **Roadmap Progress Summary**: The aggregated representation of one roadmap's progress as seen by a specific student. Contains: roadmap identity, total node count, counts per status (Done / In Progress / Pending), computed completion percentage, and last activity timestamp.
 - **Roadmap Progress Cache**: The stored copy of a Roadmap Progress Summary, maintained by the Skill Tree system and read by the dashboard. Updated every time a node's status changes on the corresponding Skill Tree. Has a one-to-one relationship with a (student, roadmap) pair.
-- **Node Status Detail**: The individual course node entry shown within a roadmap's detail view. Carries the node name, its current status, and a link destination targeting the Skill Tree at that node's location.
+- **Node Status Detail**: The individual course node entry shown within a roadmap's detail view. Follows Feature 004 payload shape: `nodeId`, `courseCode`, `courseName`, `status`, `updatedAt`.
 
 ### Assumptions
 
-- A student may be enrolled in more than one roadmap; the Onboarding feature is responsible for assigning roadmaps and notifies the Skill Tree system when a new roadmap is assigned.
+- A student may own multiple roadmap documents through Feature 009 canonical lifecycle.
 - The Skill Tree system is the sole writer of node-status data. The Progress Tracking feature only reads the aggregated cache that the Skill Tree system maintains.
+- Feature 004 owns node status storage in `skill_node_statuses` and exposes `getNodesByStatus(userId, roadmapId)`.
 - The Roadmap Progress Cache is updated by the Skill Tree system synchronously (or near-synchronously) whenever a node status changes, so the dashboard's 5-second update guarantee does not require the dashboard itself to poll raw node data.
-- "Roadmap" and "Skill Tree" refer to the same learning-path concept from different perspectives: Skill Tree is the interactive tree view; Roadmap is the data entity. A student's personal set of roadmaps is the union of all learning paths assigned during or after onboarding.
+- "Roadmap" and "Skill Tree" refer to the same learning-path concept from different perspectives: Skill Tree is the interactive tree view; Roadmap is the canonical data entity owned by Feature 009.
 - Students are always authenticated before accessing the dashboard; unauthenticated users are redirected to the login page.
 - Node type in this feature is exclusively `Course`, consistent with the scope defined in the Skill Tree specification.
 
@@ -138,7 +149,7 @@ A student has the Progress Dashboard open in one browser tab and the Skill Tree 
 
 ### Measurable Outcomes
 
-- **SC-001**: The Progress Dashboard loads fully and displays all roadmap summary cards within 2 seconds on a 4G mobile connection, for students enrolled in up to 10 roadmaps.
+- **SC-001**: The Progress Dashboard loads fully and displays all roadmap summary cards within 2 seconds on a 4G mobile connection, for students owning up to 10 completed roadmaps.
 - **SC-002**: The completion percentage displayed on a roadmap's summary card matches the progress bar percentage shown on the corresponding Skill Tree page to within ±1 percentage point (accounting for rounding), at all times.
-- **SC-003**: A student enrolled in multiple roadmaps sees every enrolled roadmap on the dashboard and can select any of them to view a complete node-by-status breakdown; no roadmap is omitted.
+- **SC-003**: A student owning multiple roadmaps sees every owned roadmap on the dashboard and can select any of them to view a complete node-by-status breakdown; no roadmap is omitted.
 - **SC-004**: After a student changes a node's status on the Skill Tree, the corresponding roadmap card on the Progress Dashboard reflects the updated percentage and node counts within 5 seconds, with no manual page reload required.


### PR DESCRIPTION
Refine Feature 007 docs to match Feature 009 canonical roadmap ownership and Feature 004 node-status contract.

Detailed changes:

- spec.md: switch dashboard scope from enrolled to owned roadmaps; add stable roadmapId requirement from 009; adopt 004 getNodesByStatus contract; add soft-fail + eventual consistency policy for refreshCache; update FR/SC/edge cases accordingly.

- plan.md: update architecture summary and technical context for multi-roadmap ownership; clarify cross-module boundaries with 004/009; include soft-fail + eventual consistency behavior in constraints and testing.

- data-model.md: update cache cardinality for multi-roadmap (0..N per user); add roadmapName and isPrimary snapshot fields; revise indexes for user+recency and optional primary-first sorting; replace direct roadmap_nodes aggregation assumption with 004 contract-backed computation; document retry/repair behavior.

- contracts/rest-api.md: update summaries API semantics to owned roadmaps; add isPrimary in summary/SSE payload; normalize node detail payload to 004 shape (courseCode/courseName/status/updatedAt); clarify ownership-based 403 behavior and stable roadmapId deep-link semantics.

- research.md: revise decisions to reflect soft-fail + eventual consistency retry; update cache computation strategy to consume 004 grouped contract; add explicit decision for 009 canonical ownership as dashboard source of truth.