### PR TITLE
spec(005-account-management): own global identity/privacy preferences

### DIFF
--- a/specs/005-account-management/contracts/rest-api.md
+++ b/specs/005-account-management/contracts/rest-api.md
@@ -37,6 +37,17 @@ Content-Type: application/json
 | 429 | `RATE_LIMITED` | Too many requests in window |
 | 500 | `INTERNAL_ERROR` | Unexpected server error |
 
+### Identity render conventions (global)
+
+`displayName` is the primary public identity field. APIs expose `effectiveDisplayName` (server-computed) to guarantee consistent rendering across clients using fallback order:
+
+1. valid `displayName`
+2. `fullName`
+3. sanitized local-part of `email`
+4. `"Student"`
+
+`privacySetting` is owned by Feature 005 and is stored on `users` with enum `identified | anonymous` (default `identified`).
+
 ---
 
 ## POST /api/auth/register
@@ -49,6 +60,7 @@ Register a new student account. Sends an OTP email and creates a `pending-verifi
 
 ```json
 {
+  "displayName": "NguyenA",
   "fullName": "Nguyễn Văn A",
   "email": "student@vnu.edu.vn",
   "password": "SecurePassword123!"
@@ -57,9 +69,12 @@ Register a new student account. Sends an OTP email and creates a `pending-verifi
 
 | Field | Type | Required | Constraints |
 |---|---|---|---|
+| `displayName` | string | no | 1–120 chars after trim if provided; public display identity |
 | `fullName` | string | yes | 2–200 chars; non-empty after trim |
 | `email` | string | yes | Must end in `@vnu.edu.vn`; lowercased at storage |
 | `password` | string | yes | Minimum 8 chars |
+
+If `displayName` is omitted at registration, backend initializes it from `fullName`.
 
 ### Response — 201 Created
 
@@ -474,7 +489,10 @@ Fetch the authenticated student's account and (if onboarding is complete) profil
 ```json
 {
   "userId": "64a1b2c3d4e5f6a7b8c9d0e1",
+  "displayName": "NguyenA",
   "fullName": "Nguyễn Văn A",
+  "effectiveDisplayName": "NguyenA",
+  "privacySetting": "identified",
   "email": "student@vnu.edu.vn",
   "avatarUrl": null,
   "linkedGoogleAccounts": [],
@@ -488,7 +506,10 @@ Fetch the authenticated student's account and (if onboarding is complete) profil
 ```json
 {
   "userId": "64a1b2c3d4e5f6a7b8c9d0e1",
+  "displayName": "NguyenA",
   "fullName": "Nguyễn Văn A",
+  "effectiveDisplayName": "NguyenA",
+  "privacySetting": "identified",
   "email": "student@vnu.edu.vn",
   "avatarUrl": "https://cdn.example.com/avatar.jpg",
   "linkedGoogleAccounts": [
@@ -521,7 +542,9 @@ Update account info and/or onboarding profile fields. Only provided fields are u
 
 ```json
 {
+  "displayName": "Nguyen Van B",
   "fullName": "Nguyễn Văn B",
+  "privacySetting": "anonymous",
   "avatarUrl": "https://cdn.example.com/new-avatar.jpg",
   "profile": {
     "major": "Software Engineering",
@@ -538,7 +561,9 @@ Update account info and/or onboarding profile fields. Only provided fields are u
 
 | Field | Notes |
 |---|---|
+| `displayName` | Optional; public identity field; maxlength 120 |
 | `fullName` | Optional; maxlength 200 |
+| `privacySetting` | Optional; enum: `identified` \| `anonymous` |
 | `avatarUrl` | Optional; valid URL or `null` |
 | `profile.*` | Only available (and applied) when `onboardingState === 'COMPLETED'`; ignored otherwise |
 

--- a/specs/005-account-management/data-model.md
+++ b/specs/005-account-management/data-model.md
@@ -2,7 +2,7 @@
 
 **Feature**: `005-account-management`
 **Date**: 2026-03-11
-**Research dependency**: [research.md](research.md) (R-002, R-003, R-004, R-005, R-006, R-007, R-008)
+**Research dependency**: [research.md](research.md) (R-002, R-003, R-004, R-005, R-006, R-007, R-008, R-010)
 
 ---
 
@@ -10,7 +10,7 @@
 
 **MongoDB collection**: `users`
 
-**Purpose**: Primary account document for every UET student. Owns authentication credentials, account status, lockout state, OTP sub-documents, linked Google accounts, and the deletion token. Created at registration (status `pending-verification`); activated after OTP verification.
+**Purpose**: Primary account document for every UET student. Owns authentication credentials, account status, global account preferences (`privacySetting`), identity fields (`displayName` public + `fullName` private/editable), lockout state, OTP sub-documents, linked Google accounts, and the deletion token. Created at registration (status `pending-verification`); activated after OTP verification.
 
 ### Schema
 
@@ -19,7 +19,9 @@
 | `_id` | ObjectId | auto | — | — | MongoDB primary key |
 | `email` | String | yes | — | **Unique index**; must end in `@vnu.edu.vn`; lowercased at write | Auth identifier |
 | `passwordHash` | String\|null | no | `null` | bcryptjs hash (12 rounds) | `null` for Google-only accounts |
-| `fullName` | String | yes | — | maxlength: 200; non-empty | |
+| `displayName` | String\|null | no | `null` | maxlength: 120; trimmed; empty string normalized to `null` | Primary public identity field (owner: Feature 005) |
+| `fullName` | String | yes | — | maxlength: 200; non-empty after trim | Editable independently from `displayName` |
+| `privacySetting` | String (enum) | yes | `'identified'` | `identified \| anonymous` | Global account preference (owner: Feature 005) |
 | `avatarUrl` | String\|null | no | `null` | Valid URL or `null` | Stored as URL, not binary |
 | `status` | String (enum) | yes | `'pending-verification'` | `pending-verification \| active \| locked \| deleted` | See state machine below |
 | `failedLoginAttempts` | Number | yes | `0` | ≥ 0; reset to 0 on success | Consecutive wrong-password counter |
@@ -61,6 +63,19 @@
 |---|---|---|---|
 | `_id` (default) | `_id` | Unique | MongoDB default |
 | `email_unique` | `email` | **Unique** | One account per email (across all auth methods) |
+
+### Identity rendering policy (global)
+
+Any user-facing identity rendering MUST follow this order:
+
+1. Valid `displayName` (non-empty after trim, passes name validation)
+2. `fullName`
+3. Sanitized email local-part (substring before `@`, non `[a-zA-Z0-9._-]` chars removed)
+4. Literal fallback `"Student"`
+
+**Notes**:
+- `privacySetting = anonymous` does not delete identity fields; it changes which fields public surfaces may expose directly.
+- API responses may include a server-computed effective display value to guarantee consistent rendering across clients.
 
 ### Account State Machine
 

--- a/specs/005-account-management/plan.md
+++ b/specs/005-account-management/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Build the authentication and account-management foundation for UETCompass: email/password registration (OTP-based email verification), Google Sign-In (GIS with `@vnu.edu.vn` domain enforcement), login with 5-attempt lockout, forgot-password via OTP, post-login routing by onboarding state, Account Settings (profile edits + re-personalization signal → Feature 004, change password, Google link/unlink, hard-delete with email confirmation), and logout. Sessions are managed with short-lived JWTs (15 min access token in memory) + opaque refresh tokens stored as SHA-256 hashes in a `refresh_tokens` MongoDB collection with httpOnly cross-site cookies. Passwords are hashed with `bcryptjs`. All auth logic lives in `backend/src/modules/auth/`. A shared `notifications` module handles in-app notification delivery (SSE + persistence) consumed by both this feature and Feature 004.
+Build the authentication and account-management foundation for UETCompass: email/password registration (OTP-based email verification), Google Sign-In (GIS with `@vnu.edu.vn` domain enforcement), login with 5-attempt lockout, forgot-password via OTP, post-login routing by onboarding state, Account Settings (global account preferences + profile edits + re-personalization signal → Feature 004, change password, Google link/unlink, hard-delete with email confirmation), and logout. Feature 005 is the owner of global account preferences on `users`: `privacySetting` (`identified | anonymous`) and identity split (`displayName` as primary public field, `fullName` editable independently). Identity rendering follows a unified fallback policy: valid `displayName` → `fullName` → sanitized email local-part → `"Student"`. Sessions are managed with short-lived JWTs (15 min access token in memory) + opaque refresh tokens stored as SHA-256 hashes in a `refresh_tokens` MongoDB collection with httpOnly cross-site cookies. Passwords are hashed with `bcryptjs`. All auth logic lives in `backend/src/modules/auth/`. A shared `notifications` module handles in-app notification delivery (SSE + persistence) consumed by both this feature and Feature 004.
 
 ## Technical Context
 
@@ -14,7 +14,7 @@ Build the authentication and account-management foundation for UETCompass: email
 - Backend: `express.js`, `mongoose 8`, `jsonwebtoken`, `bcryptjs`, `nodemailer`, `google-auth-library`, `cors`, `cookie-parser`, `helmet`, `express-rate-limit`, `uuid`
 - Frontend: `React 18`, `React Router v6`, `@react-oauth/google` (Google Identity Services wrapper), native `EventSource` (SSE — reused from Feature 001)
 
-**Storage**: MongoDB Atlas free tier — `users` collection (auth + lockout state), `refresh_tokens` collection (RT rotation + reuse detection with TTL index), `notifications` collection (in-app notification persistence); `student_profiles` collection (read/write — owned by Feature 001, extended here with `repersonalizationPending` flag)
+**Storage**: MongoDB Atlas free tier — `users` collection (auth + lockout state + global identity/privacy preferences: `displayName`, `fullName`, `privacySetting`), `refresh_tokens` collection (RT rotation + reuse detection with TTL index), `notifications` collection (in-app notification persistence); `student_profiles` collection (read/write — owned by Feature 001, extended here with `repersonalizationPending` flag)
 **Testing**: Jest 29 — unit tests only; MongoDB, `bcryptjs`, `google-auth-library`, `nodemailer` all mocked
 **Target Platform**: Backend → Render (Node.js web service, free tier, cold start ~50s); Frontend → Vercel (React SPA)
 **Project Type**: Web application — React SPA + Node.js/Express REST API (modular monolith)
@@ -28,9 +28,9 @@ Build the authentication and account-management foundation for UETCompass: email
 
 - [x] **Modular Monolithic**: All auth logic is isolated in `backend/src/modules/auth/`. Shared notification delivery lives in `backend/src/modules/notifications/`. The re-personalization signal is written to `student_profiles.repersonalizationPending` via `studentProfileService` (service-layer call only — no direct cross-module import). No microservice split introduced.
 - [x] **UET-First**: `@vnu.edu.vn` domain constraint is hardcoded in both client-side form validation and server-side Google ID token verification. No abstraction for other universities.
-- [x] **Privacy**: Passwords are stored as bcrypt hashes only — never plaintext, never logged. UET portal credentials are not involved in this feature. No password history surfaced to users. Only the minimum account data (name, email, avatar, lockout counters, OTP state) is stored — no grades, transcripts, or credential scraping.
+- [x] **Privacy**: Passwords are stored as bcrypt hashes only — never plaintext, never logged. UET portal credentials are not involved in this feature. No password history surfaced to users. Only the minimum account data (display/public name, legal/full name, privacy preference, email, avatar, lockout counters, OTP state) is stored — no grades, transcripts, or credential scraping.
 - [x] **AI-Assisted**: Gemini API is **not called** in this feature. All validation (email domain, OTP check, password confirmation) is pure code logic. No LLM involved.
-- [x] **Test What Matters**: Unit tests mandatory for: OTP expiry + lockout logic (`auth.service.test.js`), bcrypt hash/verify (`password.service.test.js`), refresh token rotation + reuse detection (`token.service.test.js`), re-personalization change detection (`profileSettings.service.test.js`).
+- [x] **Test What Matters**: Unit tests mandatory for: OTP expiry + lockout logic (`auth.service.test.js`), bcrypt hash/verify (`password.service.test.js`), refresh token rotation + reuse detection (`token.service.test.js`), re-personalization change detection (`profileSettings.service.test.js`), identity fallback + privacy rendering policy (`profileSettings.service.test.js` or dedicated identity policy unit test).
 
 ## Project Structure
 
@@ -40,7 +40,7 @@ Build the authentication and account-management foundation for UETCompass: email
 specs/005-account-management/
 ├── plan.md              ← this file
 ├── spec.md              ← feature requirements
-├── research.md          ← Phase 0: 9 technical decisions resolved
+├── research.md          ← Phase 0: 10 technical decisions resolved
 ├── data-model.md        ← Phase 1: users, refresh_tokens, notifications schemas
 ├── quickstart.md        ← Phase 1: local dev setup + manual test guide
 ├── contracts/
@@ -61,7 +61,7 @@ backend/
 │   │   │   ├── password.service.js        # bcryptjs hash/verify, password reset flow
 │   │   │   ├── google.service.js          # google-auth-library ID token verification
 │   │   │   ├── deletion.service.js        # hard delete cascade, deletion token flow
-│   │   │   ├── profileSettings.service.js # update name/avatar/onboarding fields, re-personalization diff
+│   │   │   ├── profileSettings.service.js # update displayName/fullName/privacySetting/avatar + onboarding fields, re-personalization diff
 │   │   │   ├── auth.controller.js         # Express handlers (thin)
 │   │   │   ├── auth.routes.js             # /api/auth/* routes + middleware
 │   │   │   └── auth.email.js              # OTP and deletion confirmation emails via Nodemailer
@@ -79,7 +79,7 @@ backend/
             ├── auth.service.test.js        # OTP expiry, account lock/unlock, duplicate email
             ├── token.service.test.js       # RT rotation, reuse detection, family revocation
             ├── password.service.test.js    # bcrypt hash, verify, wrong-password counter
-            └── profileSettings.service.test.js  # diff detection, repersonalizationPending flag set
+            └── profileSettings.service.test.js  # diff detection, repersonalizationPending flag set, identity fallback policy
 
 frontend/
 ├── src/
@@ -88,7 +88,7 @@ frontend/
 │   │       ├── LoginPage.jsx              # Email+password form + Google Sign-In button
 │   │       ├── RegisterPage.jsx           # Registration form + OTP verification step
 │   │       ├── ForgotPasswordPage.jsx     # Email input → OTP → new password
-│   │       ├── AccountSettingsPage.jsx    # Profile fields + password change + Google links + delete
+│   │       ├── AccountSettingsPage.jsx    # Identity/privacy prefs + profile fields + password change + Google links + delete
 │   │       ├── useAuth.js                 # Hook: login, logout, silentRefresh (60s timeout + 2 retries)
 │   │       ├── useGoogleAuth.js           # Hook: @react-oauth/google useGoogleLogin wrapper
 │   │       └── auth.api.js                # Fetch wrappers for all /api/auth/* endpoints

--- a/specs/005-account-management/research.md
+++ b/specs/005-account-management/research.md
@@ -261,3 +261,47 @@ This state is included in the login/token response payload (not in the JWT itsel
 **Alternatives considered**:
 - Separate `GET /api/auth/me` endpoint called on mount (valid, but adds a round-trip; inline in login response is cheaper)
 - Encoding onboarding state in the JWT payload (rejected — JWT is not refreshed on onboarding submission; the flag would become stale until the next login)
+
+---
+
+## R-010: Global Identity Preferences Ownership (displayName/fullName/privacy)
+
+**Decision**: Feature 005 owns global account preferences on `users` by introducing:
+- `privacySetting`: enum `identified | anonymous`, default `identified`
+- `displayName`: primary public identity field
+- `fullName`: separate editable field (independent from `displayName`)
+
+Identity rendering is standardized with one fallback policy used by all clients and API consumers:
+1. valid `displayName`
+2. `fullName`
+3. sanitized local-part of `email`
+4. literal `"Student"`
+
+The backend computes and returns `effectiveDisplayName` in account/profile responses so frontend apps do not diverge in rendering behavior.
+
+**Rationale**: Splitting `displayName` from `fullName` decouples public identity presentation from legal/private naming needs. Storing `privacySetting` on `users` keeps global account preferences in the same ownership boundary as authentication and account lifecycle (Feature 005), avoiding cross-feature coupling. Server-computed fallback output prevents inconsistent UI identity behavior across web surfaces.
+
+**Pattern**:
+```js
+function sanitizeEmailLocalPart(email) {
+  const [local = ''] = String(email || '').split('@');
+  return local.replace(/[^a-zA-Z0-9._-]/g, '').trim();
+}
+
+function isValidDisplayName(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function resolveEffectiveDisplayName({ displayName, fullName, email }) {
+  if (isValidDisplayName(displayName)) return displayName.trim();
+  if (isValidDisplayName(fullName)) return fullName.trim();
+  const localPart = sanitizeEmailLocalPart(email);
+  if (localPart.length > 0) return localPart;
+  return 'Student';
+}
+```
+
+**Alternatives considered**:
+- Keep only `fullName` and derive public display from it (rejected — cannot support independent public identity preferences)
+- Store privacy preferences in a separate `user_preferences` collection (rejected — unnecessary extra read/join for global account fields)
+- Let each frontend implement fallback logic independently (rejected — drift risk and inconsistent UX)

--- a/specs/005-account-management/spec.md
+++ b/specs/005-account-management/spec.md
@@ -101,9 +101,9 @@ After every successful login — regardless of login method — the system route
 
 ---
 
-### User Story 6 – Update Profile and Trigger Roadmap Re-personalization (Priority: P2)
+### User Story 6 – Update Profile, Identity Preferences, and Trigger Roadmap Re-personalization (Priority: P2)
 
-A student who has completed onboarding opens Account Settings and updates their personal information, including fields originally entered during onboarding. The system detects changed onboarding fields, places a "Re-personalize" button in the roadmap view (Feature 004), and delivers an in-app notification with a direct link to navigate to the roadmap.
+A student who has completed onboarding opens Account Settings and updates their personal information, including identity settings (`displayName`, `fullName`, `privacySetting`) and fields originally entered during onboarding. The system detects changed onboarding fields, places a "Re-personalize" button in the roadmap view (Feature 004), and delivers an in-app notification with a direct link to navigate to the roadmap.
 
 **Why this priority**: Profile updates enable the skill tree and roadmap to reflect the student's current situation, not just their initial snapshot. Without this feedback loop, the learning path becomes stale.
 
@@ -111,10 +111,10 @@ A student who has completed onboarding opens Account Settings and updates their 
 
 **Acceptance Scenarios**:
 
-1. **Given** a student has completed onboarding, **When** they open Account Settings, **Then** they can edit their full name, profile picture, and all onboarding profile fields.
+1. **Given** a student has completed onboarding, **When** they open Account Settings, **Then** they can edit `displayName`, `fullName`, `privacySetting`, profile picture, and all onboarding profile fields.
 2. **Given** the student changes one or more onboarding fields and saves, **When** the save is confirmed, **Then** the system detects the change and places a "Re-personalize" button in the roadmap view.
 3. **Given** the change is saved, **When** the in-app notification is delivered, **Then** it contains a direct link that navigates the student to the roadmap view.
-4. **Given** the student updates only non-onboarding fields (name, avatar), **When** the save is confirmed, **Then** no "Re-personalize" button appears and no re-personalization notification is sent.
+4. **Given** the student updates only non-onboarding fields (`displayName`, `fullName`, `privacySetting`, avatar), **When** the save is confirmed, **Then** no "Re-personalize" button appears and no re-personalization notification is sent.
 5. **Given** a student has not yet completed onboarding, **When** they open Account Settings, **Then** the onboarding profile fields are not shown as editable — only name and profile picture are available.
 
 ---
@@ -163,6 +163,8 @@ A logged-in student chooses to log out. The session is terminated immediately wi
 - **Account locked by 5 failed logins while also needing a password reset**: The student must wait for the 15-minute lockout to expire before the forgot-password flow becomes usable.
 - **Deletion confirmation link expired or already used**: The student sees a clear error message; no deletion is performed.
 - **"Re-personalize" button ignored by student after profile update**: The button persists in the roadmap view until acted upon — it does not auto-dismiss or reset.
+- **`displayName` is empty/invalid for rendering**: UI MUST apply fallback order: valid `displayName` → `fullName` → sanitized email local-part → `"Student"`.
+- **`privacySetting = anonymous`**: Public-facing surfaces MUST use the fallback render output and MUST NOT expose raw `fullName` unless the viewer is the account owner.
 
 ---
 
@@ -212,11 +214,11 @@ A logged-in student chooses to log out. The session is terminated immediately wi
 
 **Account Settings**
 
-- **FR-026**: A student MUST be able to update their full name and profile picture at any time after account creation.
+- **FR-026**: A student MUST be able to update `displayName`, `fullName`, `privacySetting` (`identified | anonymous`), and profile picture at any time after account creation.
 - **FR-027**: After a student has submitted onboarding, all onboarding profile fields (major, completed courses, target job role, target company type, graduation timeline, personal aspirations) MUST be displayed and editable within Account Settings.
 - **FR-028**: When a student saves changes to one or more onboarding profile fields, the system MUST detect the change and place a "Re-personalize" button in the roadmap view (Feature 004).
 - **FR-029**: Simultaneously with placing the "Re-personalize" button, the system MUST deliver an in-app notification containing a direct link that navigates the student to the roadmap view.
-- **FR-030**: Saving changes to non-onboarding fields (name, avatar) MUST NOT trigger the "Re-personalize" button or any re-personalization notification.
+- **FR-030**: Saving changes to non-onboarding fields (`displayName`, `fullName`, `privacySetting`, avatar) MUST NOT trigger the "Re-personalize" button or any re-personalization notification.
 - **FR-031**: A student MUST be able to change their password by entering their current password and a new password; the current password MUST be verified before the change takes effect.
 - **FR-032**: A student MUST be able to link one or more Google accounts (with a `@vnu.edu.vn` email) as additional sign-in methods.
 - **FR-033**: A student MUST be able to unlink a previously linked Google account; the student's remaining sign-in credentials MUST remain valid after unlinking.
@@ -224,10 +226,17 @@ A logged-in student chooses to log out. The session is terminated immediately wi
 - **FR-035**: Account deletion MUST only execute after the student clicks the valid confirmation link; clicking the link MUST permanently delete all personal data and mark the email as deleted.
 - **FR-036**: Once an email is marked as deleted, it MUST be eligible for use in a new account registration.
 
+**Global Identity & Privacy Preferences**
+
+- **FR-037**: `displayName` MUST be treated as the primary public identity field, stored on `users`, and editable independently from `fullName`.
+- **FR-038**: The system MUST support `privacySetting` on `users` with enum values `identified | anonymous` and default `identified`.
+- **FR-039**: The system MUST expose and accept `displayName`, `fullName`, and `privacySetting` explicitly in account/profile APIs.
+- **FR-040**: Any UI that renders student identity MUST use unified fallback order: (1) valid `displayName`, (2) `fullName`, (3) sanitized email local-part, (4) `"Student"`.
+
 **Logout**
 
-- **FR-037**: The system MUST terminate the student's session immediately upon logout with no confirmation step required.
-- **FR-038**: After logout, every attempt to access an authenticated route MUST redirect the student to the login page.
+- **FR-041**: The system MUST terminate the student's session immediately upon logout with no confirmation step required.
+- **FR-042**: After logout, every attempt to access an authenticated route MUST redirect the student to the login page.
 
 ---
 
@@ -238,12 +247,13 @@ A logged-in student chooses to log out. The session is terminated immediately wi
 - **NFR-003 (Privacy)**: No history of previous passwords is surfaced to the user; only internal audit records are maintained.
 - **NFR-004 (Isolation)**: Only the authenticated student may read or modify their own account data — cross-account access by other students MUST NOT be possible.
 - **NFR-005 (Consistency)**: A single `@vnu.edu.vn` email address MUST be associated with at most one student account at any time, regardless of which login method was used to create it.
+- **NFR-006 (Privacy)**: When `privacySetting = anonymous`, public surfaces MUST not disclose personally identifying account fields beyond the defined fallback identity output.
 
 ---
 
 ### Key Entities
 
-- **StudentAccount**: Represents a UET student's account. Key attributes: full name, `@vnu.edu.vn` email, password credential, account status (pending-verification / active / locked / deleted), list of linked Google accounts, creation timestamp, last login timestamp.
+- **StudentAccount**: Represents a UET student's account. Key attributes: `displayName` (public), `fullName` (private/editable), `privacySetting` (`identified | anonymous`), `@vnu.edu.vn` email, password credential, account status (pending-verification / active / locked / deleted), list of linked Google accounts, creation timestamp, last login timestamp.
 - **EmailVerificationToken**: A one-time 4-digit OTP issued at registration. Attributes: code, expiry (2 minutes from issue), owning account reference, status (pending / used / expired).
 - **PasswordResetToken**: A one-time 4-digit OTP issued for password recovery. Attributes: code, expiry (2 minutes from issue), email it was requested for, consecutive wrong-attempt count (resets at 10), status (pending / used / expired).
 - **LoginAttemptRecord**: Tracks consecutive failed login attempts per account, used to enforce the 5-failure lockout and the 15-minute lockout timer.
@@ -263,6 +273,7 @@ A logged-in student chooses to log out. The session is terminated immediately wi
 - **SC-005**: Account deletion is only executed after the student clicks the email confirmation link; 100% of personal data is permanently removed and the email is immediately eligible for re-registration.
 - **SC-006**: When onboarding profile fields are updated in Account Settings, the "Re-personalize" button appears in the roadmap view and an in-app notification with a direct roadmap link is delivered within 5 seconds of the save being confirmed.
 - **SC-007**: A student with an incomplete onboarding draft always sees their complete draft restored in the Onboarding Panel on every subsequent login — zero data is lost across sessions or interruptions.
+- **SC-008**: `GET/PATCH /api/account/profile` read/write `displayName`, `fullName`, and `privacySetting` consistently, and identity rendering always resolves with fallback order (`displayName` → `fullName` → sanitized email local-part → `"Student"`).
 
 ---
 


### PR DESCRIPTION
Refine Feature 005 to become the explicit owner of global account preferences and identity rendering policy.

Detailed changes:

- Added User.privacySetting with enum identified|anonymous and default identified across spec, plan, data model, and API contract.

- Normalized identity fields: displayName is now the primary public identity field; fullName remains separate and independently editable.

- Standardized identity fallback rendering policy in docs: valid displayName -> fullName -> sanitized email local-part -> Student.

- Updated functional and non-functional requirements to cover identity/privacy ownership, API exposure, and anonymous-mode behavior on public surfaces.

- Extended success criteria to validate consistent read/write + fallback resolution for displayName/fullName/privacySetting.

- Updated data model User schema with displayName and privacySetting, and documented global identity render conventions.

- Updated REST API contract:

  * POST /api/auth/register accepts optional displayName and initializes from fullName when omitted.

  * GET /api/account/profile returns displayName, fullName, privacySetting, and effectiveDisplayName.

  * PATCH /api/account/profile explicitly accepts displayName/fullName/privacySetting.

  * Added common identity render conventions section with server-computed effectiveDisplayName.

- Updated implementation plan summary, storage context, module responsibilities, and testing expectations to include identity/privacy preference ownership.

- Added research decision R-010 documenting ownership rationale, fallback algorithm, and alternatives considered.

- Synced metadata references (research decision count and dependencies) after introducing the new decision.

No source code behavior change in this commit; this commit aligns and hardens feature documentation/contracts for upcoming implementation.