### PR TITLE
docs(onboarding): align feature 001 with canonical profile contract

### DIFF
--- a/specs/001-profile-onboarding/contracts/rest-api.md
+++ b/specs/001-profile-onboarding/contracts/rest-api.md
@@ -9,6 +9,10 @@
 
 ## Common Conventions
 
+`careerGoal` remains a nested object in all request/response bodies. Any downstream/read-model `careerGoalRole` field is derived from `careerGoal.role` only.
+
+`privacySetting` is out of scope for onboarding payloads and must not appear in this contract (owned by `User` / feature 005).
+
 **Request headers** (all endpoints):
 ```
 Authorization: Bearer <JWT>
@@ -50,7 +54,17 @@ No body.
 {
   "isDraft": true,
   "major": "Computer Science",
-  "completedCourseIds": ["64a1b2c3d4e5f6a7b8c9d0e1", "64a1b2c3d4e5f6a7b8c9d0e2"],
+  "completedCourses": [
+    {
+      "major": "Computer Science",
+      "courseCode": "INT2204",
+      "courseUnitId": "64a1b2c3d4e5f6a7b8c9d0e1"
+    },
+    {
+      "major": "Computer Science",
+      "courseCode": "INT2211"
+    }
+  ],
   "careerGoal": {
     "role": "Backend Engineer",
     "companyType": null,
@@ -91,7 +105,13 @@ All fields optional. The server merges the provided fields into the existing dra
 ```json
 {
   "major": "Computer Science",
-  "completedCourseIds": ["64a1b2c3d4e5f6a7b8c9d0e1"],
+  "completedCourses": [
+    {
+      "major": "Computer Science",
+      "courseCode": "INT2204",
+      "courseUnitId": "64a1b2c3d4e5f6a7b8c9d0e1"
+    }
+  ],
   "careerGoal": {
     "role": "Backend Engineer",
     "companyType": null,
@@ -104,11 +124,13 @@ All fields optional. The server merges the provided fields into the existing dra
 | Field | Type | Constraints |
 |---|---|---|
 | `major` | string \| null | Any string; no server-side allowlist check on draft (checked on submit) |
-| `completedCourseIds` | ObjectId[] | Array of valid ObjectId strings |
+| `completedCourses` | Array<{ major, courseCode, courseUnitId? }> | Canonical identity is (`major`, `courseCode`); `courseUnitId` optional for join optimization |
 | `careerGoal.role` | string \| null | `validateFreeText()` if non-null; maxlength 500 |
 | `careerGoal.companyType` | string \| null | `validateFreeText()` if non-null; maxlength 500 |
 | `careerGoal.graduationTimeline` | string \| null | maxlength 100 |
 | `personalAspirations` | string \| null | `validateFreeText()` if non-null; maxlength 1000 |
+
+If duplicate items with same (`major`, `courseCode`) are sent, server canonicalizes to one record.
 
 ### Response — 200 OK
 
@@ -142,7 +164,13 @@ Same shape as `PUT /draft`. The full profile state at the time of submission. `m
 ```json
 {
   "major": "Computer Science",
-  "completedCourseIds": ["64a1b2c3d4e5f6a7b8c9d0e1"],
+  "completedCourses": [
+    {
+      "major": "Computer Science",
+      "courseCode": "INT2204",
+      "courseUnitId": "64a1b2c3d4e5f6a7b8c9d0e1"
+    }
+  ],
   "careerGoal": {
     "role": "Backend Engineer",
     "companyType": "Product company",
@@ -155,6 +183,7 @@ Same shape as `PUT /draft`. The full profile state at the time of submission. `m
 | Field | Required | Notes |
 |---|---|---|
 | `major` | **yes** | Must be a non-empty string matching a known UET major |
+| `completedCourses` | no | Canonical identity by (`major`, `courseCode`); `courseUnitId` optional |
 | all other fields | no | Omitting all optional fields is valid — triggers generic roadmap (BR-003) |
 
 ### Response — 202 Accepted
@@ -284,3 +313,9 @@ data: {"code":"UNAUTHORIZED","message":"Invalid or missing token"}
 When roadmap generation fails (communicated via SSE or email), the student can retry generation. This endpoint lives in the `roadmap` module and is triggered from the frontend. The onboarding module communicates the failure status; the retry action is handled by the roadmap service layer.
 
 This is documented here for cross-reference only — it is **not implemented** by the onboarding module.
+
+---
+
+## Pre-Implementation Policy
+
+This contract update is pre-implementation alignment. Runtime migration/backfill is not part of onboarding request handling.

--- a/specs/001-profile-onboarding/data-model.md
+++ b/specs/001-profile-onboarding/data-model.md
@@ -20,7 +20,7 @@
 | `userId` | ObjectId | yes | — | **Unique index**; ref: `users` | Foreign key to authenticated user |
 | `isDraft` | Boolean | yes | `true` | — | `false` = submitted; **irreversible once false** |
 | `major` | String | on submit | `null` | Non-empty when `isDraft: false` | Selected from predefined UET major list |
-| `completedCourseIds` | ObjectId[] | no | `[]` | Each element ref: `course_units` | Completion flag only — no grade stored |
+| `completedCourses` | Array<{ major, courseCode, courseUnitId? }> | no | `[]` | Canonical identity = (`major`, `courseCode`); `courseUnitId` optional ObjectId ref `course_units` | Completion flag only — no grade stored |
 | `careerGoal.role` | String\|null | no | `null` | maxlength: 500; `validateFreeText` if non-null | Predefined option or free-text |
 | `careerGoal.companyType` | String\|null | no | `null` | maxlength: 500; `validateFreeText` if non-null | Predefined option or free-text |
 | `careerGoal.graduationTimeline` | String\|null | no | `null` | maxlength: 100 | Free-form, e.g. "3 semesters" or "2027-06" |
@@ -28,6 +28,10 @@
 | `submittedAt` | Date\|null | no | `null` | Set once on submit; never overwritten | `null` while draft |
 | `createdAt` | Date | auto | `Date.now()` | Set on first upsert (`$setOnInsert`) | |
 | `updatedAt` | Date | auto | `Date.now()` | Updated on every `PUT /onboarding/draft` and on submit | |
+
+> `careerGoalRole` is a downstream/read-model alias and MUST always be read from `careerGoal.role`.
+>
+> `privacySetting` is intentionally excluded from `StudentProfile`; ownership belongs to `User` (feature 005).
 
 ### Indexes
 
@@ -39,6 +43,12 @@
 ### Validation rules applied at service layer
 
 All free-text fields (`careerGoal.role`, `careerGoal.companyType`, `personalAspirations`) are passed through `validateFreeText()` (see [research.md R-004](research.md)) before upsert. `null` and empty string after trimming both pass — the field is treated as "not provided".
+
+For `completedCourses`, service layer canonicalizes identity by (`major`, `courseCode`) and de-duplicates repeated entries in the same payload. `courseUnitId` is optional and does not change identity semantics.
+
+## Pre-Implementation Policy
+
+This specification update is contract-alignment only. No runtime data migration/backfill is performed in onboarding APIs. Any one-off migration (if required) is handled separately as an operational task.
 
 ---
 
@@ -81,14 +91,14 @@ All free-text fields (`careerGoal.role`, `careerGoal.companyType`, `personalAspi
 
 | Field | Type | Notes |
 |---|---|---|
-| `_id` | ObjectId | Referenced by `StudentProfile.completedCourseIds` |
+| `_id` | ObjectId | Optionally referenced by `StudentProfile.completedCourses[].courseUnitId` |
 | `code` | String | e.g., `"INT2204"` |
 | `name` | String | Display name for the multi-select UI |
 | `major` | String | Used as filter: `CourseUnit.find({ major })` |
 
 See details in [data-model.md for curriculum seeding feature](../002-seed-ctdt-dag/data-model.md)
 
-**Access pattern from onboarding module**: `find({ major })` on `GET /onboarding/draft` response enrichment and on major change. No writes.
+**Access pattern from onboarding module**: `find({ major })` on `GET /onboarding/draft` response enrichment and on major change. No writes. `courseUnitId` (when present) is used as join optimization only; canonical matching remains (`major`, `courseCode`).
 
 ---
 

--- a/specs/001-profile-onboarding/plan.md
+++ b/specs/001-profile-onboarding/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-A one-time, skippable onboarding panel that appears on first login and collects a student's academic profile (major, completed courses) and career goals (role, company type, graduation timeline, personal aspirations). All form inputs are auto-saved server-side as a `StudentProfile` draft via a debounced `PUT /onboarding/draft` (800ms). On explicit student submission, the profile transitions irreversibly to `isDraft: false`, and an async roadmap generation job is fired (Promise-based, no queue). The student receives notification via SSE (in-app, while connected) and Nodemailer email (always). No LLM is called during onboarding.
+A one-time, skippable onboarding panel that appears on first login and collects a student's academic profile (major, completed courses) and career goals (role, company type, graduation timeline, personal aspirations). `careerGoal` remains a nested object; downstream `careerGoalRole` is always derived from `careerGoal.role`. Completed-course identity follows canonical rule `(`major`, `courseCode`)`, with optional `courseUnitId` persisted only for join optimization. `privacySetting` is not part of `StudentProfile` (owned by `User` in feature 005). All form inputs are auto-saved server-side as a `StudentProfile` draft via a debounced `PUT /onboarding/draft` (800ms). On explicit student submission, the profile transitions irreversibly to `isDraft: false`, and an async roadmap generation job is fired (Promise-based, no queue). The student receives notification via SSE (in-app, while connected) and Nodemailer email (always). No LLM is called during onboarding.
 
 ## Technical Context
 
@@ -22,6 +22,8 @@ A one-time, skippable onboarding panel that appears on first login and collects 
 **Constraints**: Render cold start ~50s — frontend must show loading states gracefully on first API call; no Redis/BullMQ; no WebSocket; SSE only while client connected (no server-side queue for missed events)
 **Scale/Scope**: UET-VNU students only — hundreds to low thousands of concurrent users; no multi-tenancy
 
+**Data Contract Policy**: Pre-implementation alignment only; no runtime migration/backfill is executed in onboarding request path.
+
 ## Constitution Check
 
 *Pre-design gate — re-checked after Phase 1 design: all items still pass.*
@@ -31,6 +33,7 @@ A one-time, skippable onboarding panel that appears on first login and collects 
 - [x] **Privacy**: No UET portal credentials collected or stored. Only academic profile data (major, completed courses, career goals). `personalAspirations` is voluntary free text — no sensitive credential data.
 - [x] **AI-Assisted**: Gemini API is **not called** in this feature. Free-text validation uses pure regex/string logic (`validateFreeText`) per NFR-005. No LLM calls during onboarding.
 - [x] **Test What Matters**: Unit tests cover the two complex pieces with side effects — (1) `validateFreeText` edge cases, (2) `StudentProfile` state machine transitions including duplicate-submit rejection.
+- [x] **Boundary Ownership**: `privacySetting` remains in `User` domain (feature 005), not duplicated in onboarding `StudentProfile`.
 
 ## Project Structure
 

--- a/specs/001-profile-onboarding/research.md
+++ b/specs/001-profile-onboarding/research.md
@@ -268,3 +268,34 @@ async function dispatchNotifications(userId, userEmail, displayName, status) {
 **Alternatives considered**:
 - Server-side notification queue (rejected — YAGNI; Render free tier has no Redis; significant complexity for an edge case)
 - SSE-only, no email (rejected — misses offline students entirely; violates FR-023)
+
+---
+
+## R-009: Canonical Contract Alignment (Profile Shape + Course Identity)
+
+**Decision**:
+1. Keep `careerGoal` as a nested object in persistence and API payloads.
+2. Treat downstream `careerGoalRole` as derived read-model data sourced from `careerGoal.role` only (no duplicate writable field).
+3. Exclude `privacySetting` from `StudentProfile`; ownership remains in `User` domain (feature 005).
+4. Canonicalize completed-course identity by (`major`, `courseCode`), with optional `courseUnitId` stored only as join optimization metadata.
+5. Pre-implementation policy: no runtime migration/backfill in request path for this alignment update.
+
+**Rationale**: This keeps a single source of truth for career goal role, avoids cross-feature ownership leakage for privacy settings, and makes completed-course semantics stable even if `courseUnitId` values evolve. The no-runtime-migration policy reduces risk in hot paths and keeps rollout operationally simple.
+
+**Pattern**:
+```js
+// canonical completed-course payload item
+{
+  major: 'Computer Science',
+  courseCode: 'INT2204',      // canonical identity component
+  courseUnitId: '64a1...'     // optional optimization only
+}
+
+// downstream mapping (read model only)
+const careerGoalRole = profile.careerGoal?.role ?? null;
+```
+
+**Alternatives considered**:
+- Flatten `careerGoalRole` directly in `StudentProfile` (rejected — duplicated source of truth)
+- Canonical identity by `courseUnitId` only (rejected — weaker portability across seed/version changes)
+- Runtime migration in onboarding API handlers (rejected — unnecessary coupling and latency/risk in request path)

--- a/specs/001-profile-onboarding/spec.md
+++ b/specs/001-profile-onboarding/spec.md
@@ -113,6 +113,7 @@ A student whose desired job role or target company type is not in the predefined
 - **FR-012**: The student MUST be able to specify a graduation timeline as a number of semesters remaining or an expected graduation date.
 - **FR-013**: The student MUST be able to enter personal aspirations, constraints, or preferences as free-text.
 - **FR-014**: All optional fields MUST be clearly marked as optional, and the system MUST communicate that omitting them reduces personalisation quality.
+- **FR-014a**: Career-goal payloads MUST preserve `careerGoal` as a nested object. Any downstream `careerGoalRole` projection MUST be derived from `careerGoal.role` (read-only alias, no separate source-of-truth field).
 
 **Validation**
 
@@ -135,6 +136,12 @@ A student whose desired job role or target company type is not in the predefined
 - **FR-025**: The system MUST enforce one profile per student account — duplicate submission attempts MUST be rejected.
 - **FR-026**: If a student submits with all optional fields empty, the system MUST generate a generic roadmap and clearly communicate that personalisation quality is low.
 
+**Canonical Data Contract Alignment**
+
+- **FR-029**: Completed-course identity MUST be canonicalized by the pair (`major`, `courseCode`).
+- **FR-030**: The system MAY persist `courseUnitId` as an optional optimization field for joins/indexed lookups, but identity semantics MUST remain (`major`, `courseCode`).
+- **FR-031**: `privacySetting` MUST NOT be persisted in `StudentProfile`; privacy ownership belongs to `User` (feature 005 account management).
+
 **Session Handling**
 
 - **FR-027**: If a student's session expires while filling in the onboarding panel, the system MUST redirect to the login page.
@@ -156,6 +163,7 @@ A student whose desired job role or target company type is not in the predefined
 ### Key Entities
 
 - **StudentProfile**: Represents the student's academic and career profile collected during onboarding. Contains: major selection, list of completed course identifiers, target job role (predefined or free-text), target company type (predefined or free-text), graduation timeline, personal aspirations, submission status (draft / submitted), and timestamps for creation and submission.
+- **StudentProfile**: Represents the student's academic and career profile collected during onboarding. Contains: major selection, list of completed courses canonically identified by (`major`, `courseCode`) with optional `courseUnitId`, nested `careerGoal` object (where downstream `careerGoalRole` is derived from `careerGoal.role`), personal aspirations, submission status (draft / submitted), and timestamps for creation and submission. Does **not** contain `privacySetting`.
 - **OnboardingDraft**: The intermediate state of the onboarding form before submission. Tied 1:1 to a StudentProfile. Overwritten on each real-time save; promoted to submitted status on explicit student confirmation.
 - **Major**: A predefined academic program offered at UET-VNU. Has a unique identifier, a display name, and an associated list of Course entries. Catalog data is pre-seeded by a separate system process.
 - **Course**: An academic course belonging to one or more Majors. Has a unique identifier and display name. Used for completed-course multi-select during onboarding. Catalog data is pre-seeded by a separate system process outside this feature's scope.
@@ -184,6 +192,7 @@ A student whose desired job role or target company type is not in the predefined
 - Students are fully authenticated before reaching the onboarding panel — this feature does not handle login, registration, or account creation.
 - "Real-time" draft saving is interpreted as save-on-change (debounced) or save-on-blur; exact debounce timing is a technical implementation detail.
 - The asynchronous roadmap generation system exists as a separate component; this feature is only responsible for triggering it on submission and displaying its completion or failure notification.
+- Pre-implementation policy: no runtime data migration is required for this feature-alignment update; migration/backfill (if needed) is handled as a separate operational activity.
 
 ---
 


### PR DESCRIPTION
Refine specs/001-profile-onboarding to match the new canonical data contract across spec, plan, data model, API contract, and research notes.

Detailed changes:

- Preserve careerGoal as a nested object and formalize downstream mapping rule: careerGoalRole must always be derived from careerGoal.role (no duplicate writable source of truth).

- Remove privacy ownership ambiguity by explicitly excluding privacySetting from StudentProfile; document that ownership stays in User domain (feature 005).

- Normalize completed-course identity to canonical tuple (major, courseCode) and allow optional courseUnitId as optimization-only metadata for joins/lookups.

- Update REST examples and field constraints from completedCourseIds to completedCourses object items; add server-side canonicalization note for duplicate (major, courseCode) entries.

- Add explicit pre-implementation policy: this alignment does not require runtime migration/backfill in onboarding request paths; any migration is handled separately as an operational task.

- Add research decision R-009 documenting rationale, pattern, and rejected alternatives for contract alignment.