### PR TITLE
feat(006): align auto-tagging docs with canonical search-tagging model

### DIFF
--- a/specs/006-ai-auto-tagging/contracts/rest-api.md
+++ b/specs/006-ai-auto-tagging/contracts/rest-api.md
@@ -5,6 +5,8 @@
 **Base path**: `/api/tagging`  
 **Authentication**: All endpoints require a valid JWT in `Authorization: Bearer <token>`. Middleware attaches `req.user.userId` (ObjectId) to every request.  Only users with the `admin` role may access reporting and manual review endpoints; skill ingestion endpoints are open to the internal crawler service via a shared secret header.
 
+**Bounded context**: `Skill`/`Tag` payloads are canonical contracts for the tagging/search context (shared with feature 008), not roadmap-core contracts.
+
 ---
 
 ## Common Conventions
@@ -40,6 +42,23 @@ X-Service-Key: <secret>   # required for ingestion endpoints
 
 ---
 
+## Canonical Tag Object (used across responses)
+
+```json
+{
+  "tagId": "64a9b8c7d6e5f4a3b2c1d0e",
+  "normalizedName": "javascript",
+  "confidence": 92
+}
+```
+
+Notes:
+- `normalizedName` is lowercase + trimmed canonical key for search.
+- Re-tagging follows overwrite strategy: latest successful tagging replaces the previous full tag set.
+- This shape is intentionally stable so feature 008 can consume directly without transform middleware.
+
+---
+
 ## POST /api/tagging/skills
 
 Enqueue a single skill for tagging. Typically invoked by the crawler when a new
@@ -59,7 +78,10 @@ All fields are required except `description` and `sourceCourseId`.
 
 ### Response — 202 Accepted
 ```json
-{ "jobId": "64a9b8c7d6e5f4a3b2c1d0e" }
+{
+  "jobId": "64a9b8c7d6e5f4a3b2c1d0e",
+  "status": "pending"
+}
 ```
 
 ### Response — 409 Conflict
@@ -110,7 +132,11 @@ tags if completed.
   "_id": "64a9b8c7d6e5f4a3b2c1d0e",
   "skillName": "JavaScript",
   "status": "done",
-  "resultTags": ["frontend","javascript","programming"],
+  "resultTags": [
+    { "tagId": "64aaa111d6e5f4a3b2c1d0e", "normalizedName": "frontend", "confidence": 94 },
+    { "tagId": "64aaa222d6e5f4a3b2c1d0e", "normalizedName": "javascript", "confidence": 97 },
+    { "tagId": "64aaa333d6e5f4a3b2c1d0e", "normalizedName": "programming", "confidence": 88 }
+  ],
   "confidence": 92,
   "attempts": 1,
   "createdAt": "2026-03-11T09:00:00Z",
@@ -129,7 +155,10 @@ tags or confidence.
 ```json
 {
   "status": "done",          // or "review" to keep it flagged
-  "resultTags": ["js","web"],
+  "resultTags": [
+    { "tagId": "64aaa222d6e5f4a3b2c1d0e", "normalizedName": "javascript", "confidence": 100 },
+    { "tagId": "64aaa444d6e5f4a3b2c1d0e", "normalizedName": "web", "confidence": 100 }
+  ],
   "confidence": 100
 }
 ```
@@ -156,3 +185,7 @@ Retrieve aggregate statistics for finished batches. Admin-only.
 
 These endpoints provide the minimal contract needed to ingest skills, monitor
 queue progress, and review or override tagging results.
+
+For direct search integration, consumers (feature 008) should read
+`resultTags[].normalizedName` and `resultTags[].confidence` without additional
+mapping.

--- a/specs/006-ai-auto-tagging/data-model.md
+++ b/specs/006-ai-auto-tagging/data-model.md
@@ -2,6 +2,11 @@
 
 This document enumerates the primary entities, their attributes, and relations.
 
+## Bounded Context Ownership
+
+- `Skill` and `Tag` in this feature belong to the **tagging/search bounded context**.
+- They are canonical data structures for tagging + search behavior and are **not** `roadmap-core` entities.
+
 ## Skill
 Represents a competency extracted from a course or other source.
 
@@ -12,8 +17,19 @@ Represents a competency extracted from a course or other source.
 | description  | String   | Optional short description from source   |                                |
 | sourceCourse | ObjectId | Reference to `Course` (if applicable)    | optional; for analysis         |
 | domain       | String   | e.g., "IT", "Marketing"              | used to provide context to LLM |
-| tags         | [ObjectId] | Array of Tag references                | populated after processing     |
+| tags         | [SkillTag] | Canonical search-ready tag metadata    | overwritten on re-tagging      |
 | createdAt    | Date     | Ingestion timestamp                      | indexed                        |
+
+### SkillTag (embedded metadata in `Skill.tags`)
+
+| Field          | Type     | Description                                      | Notes                                  |
+|----------------|----------|--------------------------------------------------|----------------------------------------|
+| tagId          | ObjectId | Reference to `Tag` dictionary entry              | required                               |
+| normalizedName | String   | Canonical normalized tag key (e.g., `javascript`) | required; lowercase + trimmed          |
+| confidence     | Number   | Confidence for this assignment (0–100)           | required; used by search/review logic  |
+
+`Skill.tags` follows overwrite semantics: on successful re-tagging, the entire
+array is replaced by the latest canonical output.
 
 ## Tag
 Represents a classification label assigned to skills.
@@ -21,13 +37,17 @@ Represents a classification label assigned to skills.
 | Field        | Type     | Description                              | Notes                          |
 |--------------|----------|------------------------------------------|--------------------------------|
 | _id          | ObjectId | Primary key                              |                                |
-| name         | String   | e.g., "frontend", "javascript"       | unique, case-normalized        |
+| name         | String   | Human-facing label (e.g., "JavaScript") | dictionary/management source    |
+| normalizedName | String | Canonical key (e.g., "javascript")      | unique, lowercase + trimmed     |
 | category     | String   | Optional category (e.g., "language")   | for future filtering           |
 | usageCount   | Number   | Number of skills tagged with this label  | incremented on assignment      |
 | createdAt    | Date     | Timestamp of tag creation                |                                |
 
-A unique index on `name` avoids duplicates; normalization to lowercase plus
-trimming is applied before persistence.
+A unique index on `normalizedName` avoids duplicates; normalization to lowercase
+plus trimming is applied before persistence.
+
+`Tag` acts as dictionary and lifecycle management source. `Skill.tags` stores
+the canonical assignment snapshot for search execution.
 
 ## TaggingJob
 Implements the queue and audit log for asynchronous processing.
@@ -39,7 +59,7 @@ Implements the queue and audit log for asynchronous processing.
 | status       | String     | `pending`, `in_progress`, `done`, `failed`         | indexed                        |
 | attempts     | Number     | Retry count (default 0)                             |                                |
 | lastError    | String     | Error message from last failure (optional)          |                                |
-| resultTags   | [ObjectId] | Tags assigned (populated when status=`done`)       |                                |
+| resultTags   | [SkillTag] | Canonical tags assigned when status=`done`          | mirrors `Skill.tags` shape     |
 | confidence   | Number     | Confidence score returned by LLM (0–100)           | stored for reporting/review    |
 | createdAt    | Date       | Job creation time                                   | indexed for dequeue ordering   |
 | updatedAt    | Date       | Last update timestamp                               |                                |
@@ -49,10 +69,12 @@ selection of pending jobs.
 
 ## Relationships
 
-- `Skill.tags` holds references to `Tag` documents created or reused during
-  tagging.
+- `Skill.tags` stores canonical tag metadata (`tagId`, `normalizedName`,
+  `confidence`) for direct search/query use.
 - Each `TaggingJob` links to a single Skill; multiple jobs may exist for the
   same skill in case of retries.
+- `TaggingJob.resultTags` mirrors `Skill.tags` for auditability and downstream
+  API contract consistency.
 
 ## Notes
 

--- a/specs/006-ai-auto-tagging/plan.md
+++ b/specs/006-ai-auto-tagging/plan.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Build a backend module that automatically tags newly harvested skills by sending their data to a managed LLM API and storing the resulting labels.  Inputs arrive from the crawler or ingestion service, are enqueued in a MongoDB-backed job queue, and processed in periodic batch jobs that call the LLM (OpenAI/Anthropic/Google) via HTTP.  Tags are de‑duplicated against an existing `tags` collection and new labels are added when confidence exceeds 85%.  Failures for individual items are recorded and retried automatically, while overall batch runs complete within one hour.
+Build a backend module that automatically tags newly harvested skills by sending their data to a managed LLM API and storing the resulting labels in the tagging/search bounded context. Inputs arrive from the crawler or ingestion service, are enqueued in a MongoDB-backed job queue, and processed in periodic batch jobs that call the LLM (OpenAI/Anthropic/Google) via HTTP. Tags are de‑duplicated against a dictionary `tags` collection and new labels are added when confidence exceeds 85%. Skills store canonical search-ready `Skill.tags` metadata (`tagId`, `normalizedName`, `confidence`) and apply overwrite strategy on re-tagging. Failures for individual items are recorded and retried automatically, while overall batch runs complete within one hour. API outputs are normalized for direct consumption by feature 008 (advanced tag search).
 
 ## Technical Context
 
@@ -28,11 +28,14 @@ Build a backend module that automatically tags newly harvested skills by sending
 **Performance Goals**: Process 1k–10k skills/day, complete each batch within 1 hour, maintain <1% per-item failure and <10% manual review rate.
 **Constraints**: No Redis/BullMQ per constitution; queue must run on MongoDB. LLM API rate limits must be observed; budget < $X/month (estimate later). Batch job memory footprint <500MB to fit Render free tier.
 **Scale/Scope**: Single-tenant UET-VNU dataset; few million skills over first year; feature scoped to backend service only (no mobile app).
+
+**Canonical Domain Boundary**: `Skill`/`Tag` in this feature are part of the tagging/search bounded context (shared with feature 008), not `roadmap-core`.
 ## Constitution Check
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
 - **Modular Monolithic**: tagging logic will reside entirely in `backend/src/modules/tagging/` with service-layer interface. No cross-module imports except for shared `db` helper.  ✅
+- **Boundary Consistency**: `Skill`/`Tag` modeling and contracts are owned by tagging/search context and exposed in canonical form for search consumers.  ✅
 - **UET-First**: tags are specific to domains and skills relevant to UET curriculum; no generic external taxonomy required.  ✅
 - **Privacy**: only non-sensitive skill/course metadata is used; no student credentials are involved.  ✅
 - **AI-Assisted**: LLM is invoked solely for tag suggestion.  Human operators may override via manual review interface.  ✅
@@ -87,6 +90,13 @@ frontend/                          # optional admin dashboard
 ```
 
 **Structure Decision**: Option 2 — Web application with a modular monolithic backend. The tagging feature is implemented as a new module (`backend/src/modules/tagging/`) alongside existing services; the queue is MongoDB‑based, avoiding extra infrastructure. Frontend changes are confined to an optional admin dashboard under `frontend/src/features/tagging/`. This keeps the repository layout consistent with prior features.
+
+### Canonical Contract Notes (for Feature 008 interop)
+
+- `Skill.tags` is persisted in canonical search shape with fields: `tagId`, `normalizedName`, `confidence` (optionally enriched with display metadata).
+- Re-tagging overwrites prior `Skill.tags` atomically after a successful job completion.
+- `Tag` collection remains dictionary/management source for normalization, deduplication, and governance.
+- Tagging module response objects mirror persisted canonical shape to avoid downstream transform layers.
 
 ## Complexity Tracking
 

--- a/specs/006-ai-auto-tagging/research.md
+++ b/specs/006-ai-auto-tagging/research.md
@@ -69,6 +69,52 @@ not abort the whole batch and simplifies operator visibility.
   degrade throughput.
 - Silently skip failed items: would hide issues from operators.
 
+## Decision: `Skill`/`Tag` ownership in tagging/search bounded context
+
+**Rationale:**  `Skill` and `Tag` used by auto-tagging are canonical to
+tagging/search behavior and must be reused by advanced tag search (feature 008).
+Treating them as `roadmap-core` entities would couple unrelated domains and
+increase translation logic.
+
+**Alternatives considered:**
+- Keep ownership in roadmap-core and map into search indexes: adds repeated
+  transform layers and schema drift risk.
+- Duplicate skill/tag models in each feature: causes inconsistency and
+  maintenance overhead.
+
+## Decision: Canonical `Skill.tags` metadata shape + overwrite re-tagging
+
+**Rationale:**  Persisting `Skill.tags` as canonical metadata
+(`tagId`, `normalizedName`, `confidence`) is optimized for search filtering and
+ranking while preserving dictionary linkage through `tagId`. Re-tagging should
+replace the full tag snapshot to avoid stale mixed states from incremental merges.
+
+**Alternatives considered:**
+- Store only tag ObjectIds: insufficient for direct search and requires joins.
+- Append-only re-tagging: preserves history but makes active-tag reads and
+  confidence interpretation more complex.
+
+## Decision: Keep `Tag` as dictionary/management source
+
+**Rationale:**  The `Tag` entity governs normalization, deduplication,
+category metadata, and lifecycle. `Skill.tags` is the assignment snapshot for
+query/runtime use.
+
+**Alternatives considered:**
+- Flatten tags directly into skills with no dictionary: simpler writes but loses
+  governance and deduplication controls.
+
+## Decision: Standardize output contract for direct feature 008 consumption
+
+**Rationale:**  Returning canonical tag objects in API responses avoids
+intermediate transformation middleware before advanced search ingestion. This
+reduces latency, complexity, and mismatch risk between persisted data and API
+shape.
+
+**Alternatives considered:**
+- Return human-readable strings only and transform later: easier to read but not
+  canonical and insufficient for stable programmatic consumption.
+
 
 All research decisions are now documented and incorporated into the
 specification and plan.

--- a/specs/006-ai-auto-tagging/spec.md
+++ b/specs/006-ai-auto-tagging/spec.md
@@ -29,6 +29,14 @@ Logic: AI phải so sánh skill đó với bộ tag hiện có trong database ho
 - Q: How should the system process skills (synchronous vs asynchronous)? → A: Asynchronous batch processing via queue system
 - Q: How should the system handle LLM API failures during batch processing? → A: Continue processing remaining skills; mark failed skills for retry/manual review
 
+### Canonical Refinement 2026-03-14
+
+- `Skill` and `Tag` are entities of the **tagging/search bounded context** (shared by feature 006 and consumed by feature 008), not `roadmap-core` entities.
+- Canonical `Skill.tags` must be stored as search-ready metadata objects containing at least `tagId`, `normalizedName`, and `confidence`.
+- Re-tagging uses an **overwrite strategy**: latest successful tagging result replaces prior `Skill.tags` snapshot.
+- `Tag` remains the dictionary/management source for lifecycle and deduplication.
+- Output contracts are standardized so feature 008 can consume tagging results directly with no intermediate transformation.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Automatic Skill Tagging (Priority: P1)
@@ -91,14 +99,16 @@ As a data analyst, I want to review tagging accuracy metrics so that I can monit
 - **FR-001**: System MUST accept input consisting of Skill Name, Course Context, and Domain, placing skills into a processing queue.
 - **FR-002**: System MUST process queued skills asynchronously via batch processing and send the data to a managed LLM API service (OpenAI, Anthropic, or Google) for tag generation.
 - **FR-003**: System MUST receive and process tag suggestions from the LLM including confidence scores.
-- **FR-004**: System MUST compare suggested tags with existing database tags and use existing ones when appropriate.
-- **FR-005**: System MUST add new tags to the database when confidence score > 85%.
-- **FR-006**: System MUST output/store a list of assigned tags for each processed skill.
+- **FR-004**: System MUST compare suggested tags with existing database tags and map matches to canonical `Tag` entries.
+- **FR-005**: System MUST add new dictionary tags to the `Tag` store when confidence score > 85%.
+- **FR-006**: System MUST output/store canonical `Skill.tags` metadata for each processed skill with fields `tagId`, `normalizedName`, and `confidence`.
+- **FR-006a**: System MUST apply overwrite strategy on re-tagging, replacing the full `Skill.tags` set with the newest successful tagging output.
 - **FR-007**: System MUST flag skills where LLM confidence is below threshold for manual review.
 - **FR-008**: System MUST support multiple domains (IT, Marketing, etc.) for context-aware tagging.
 - **FR-009**: System MUST implement batch processing via job queue with configurable batch size and scheduling (scheduled or event-driven).
 - **FR-010**: System MUST continue processing remaining skills when LLM API fails for individual items; mark failed skills with error status and add them to a retry queue.
 - **FR-011**: System MUST provide visibility into batch processing status, including counts of successfully tagged, failed, and flagged-for-review skills.
+- **FR-012**: System MUST expose a normalized response contract for downstream search modules (feature 008) to consume directly.
 
 ### Non-Functional Requirements
 
@@ -111,8 +121,8 @@ As a data analyst, I want to review tagging accuracy metrics so that I can monit
 
 ### Key Entities *(include if feature involves data)*
 
-- **Skill**: Represents a competency or ability, with attributes like name, description, source course.
-- **Tag**: Represents a classification label, with attributes like name, category, usage count.
+- **Skill** *(tagging/search bounded context)*: Represents a competency or ability, with attributes like name, description, source course, and canonical `tags` metadata (`tagId`, `normalizedName`, `confidence`).
+- **Tag** *(tagging/search bounded context)*: Represents a dictionary classification label, with attributes like display name, normalized name, category, usage count.
 - **Course**: Represents the learning source, with attributes like title, description, domain.
 
 ## Success Criteria *(mandatory)*


### PR DESCRIPTION
Refine feature 006 to formalize Skill/Tag ownership in the tagging/search bounded context and decouple from roadmap-core assumptions.

Document canonical Skill.tags as search-ready metadata entries with tagId, normalizedName, and confidence, and define overwrite semantics for re-tagging to replace stale snapshots.

Keep Tag as dictionary/management source with normalizedName-driven deduplication and lifecycle governance.

Standardize REST contract responses to canonical tag objects so feature 008 can consume output directly without intermediate transformation.

Synchronize all related artifacts (spec, plan, data model, API contract, research notes) to ensure consistent domain language, interop assumptions, and implementation direction.