### PR TITLE
docs(search-008): align advanced tag search with canonical FEAT-006 schema and lock MVP infra

### DIFF
--- a/specs/008-advanced-tag-search/contracts/rest-api.md
+++ b/specs/008-advanced-tag-search/contracts/rest-api.md
@@ -2,9 +2,42 @@
 
 **Feature**: `008-advanced-tag-search`  
 **Date**: 2026-03-11  
-**Research dependency**: [../research.md](../research.md) (R-001 to R-007)  
+**Research dependency**: [../research.md](../research.md) (R-001 to R-008)  
 **Base URL**: `/api/search`  
 **Auth**: All endpoints require a valid JWT Access Token in the `Authorization: Bearer <token>` header, verified by the shared `auth.middleware.js`. The user ID is extracted from the JWT payload.
+
+---
+
+## Common Conventions
+
+### Canonical tag normalization
+
+- For `queryType = "tag"`, request may provide:
+  - `query.tagId`, or
+  - `query.tagNormalizedName`, or
+  - both (if consistent)
+- Backend MUST normalize to canonical `resolvedTagId` before executing the search query.
+
+### Error envelope (all non-2xx responses)
+
+```json
+{
+  "error": {
+    "code": "INVALID_INPUT",
+    "message": "Human-readable error message",
+    "details": {}
+  }
+}
+```
+
+### Error codes
+
+| HTTP | code | Meaning |
+|---|---|---|
+| 400 | `INVALID_INPUT` | Validation or normalization failed |
+| 401 | `UNAUTHORIZED` | Missing or invalid JWT |
+| 404 | `NOT_FOUND` | Resource not found (optional endpoint-specific usage) |
+| 500 | `INTERNAL_ERROR` | Unexpected server/index/cache failure |
 
 ---
 
@@ -21,16 +54,28 @@ Content-Type: application/json
 
 {
   "queryType": "tag" | "keyword",
-  "tagId": "64f1a2b3c4d5e6f7a8b9c0d1",           // required if queryType === "tag"
-  "keyword": "database",                           // required if queryType === "keyword"
+  "query": {
+    "tagId": "64f1a2b3c4d5e6f7a8b9c0d1",           // optional for tag query
+    "tagNormalizedName": "database",               // optional for tag query
+    "keyword": "database"                          // required for keyword query
+  },
   "filters": {
     "levels": ["Beginner", "Intermediate"],       // optional, AND semantics
     "domains": ["Backend"],                        // optional, AND semantics
-    "additionalTags": ["64f1a2b3c4d5e6f..."]      // optional, AND semantics
+    "additionalTagIds": ["64f1a2b3c4d5e6f..."],    // optional, AND semantics
+    "minConfidence": 60                              // optional, 0-100
   },
-  "sortBy": "relevance" | "alphabetical",         // optional, default: "relevance"
-  "page": 1,                                       // optional, default: 1, must be ≥ 1
-  "enrolledRoadmapId": "74f1a2b3c4d5e6f7a8b9c0d2" // optional, for personalization highlighting
+  "sort": {
+    "by": "relevance" | "alphabetical",          // optional, default: relevance
+    "order": "asc" | "desc"                      // optional, default: desc
+  },
+  "pagination": {
+    "page": 1,                                      // optional, default: 1, must be ≥ 1
+    "pageSize": 20                                  // optional, default: 20, range: 1-50
+  },
+  "personalization": {
+    "enrolledRoadmapId": "74f1a2b3c4d5e6f7a8b9c0d2" // optional
+  }
 }
 ```
 
@@ -39,15 +84,20 @@ Content-Type: application/json
 | Field | Type | Required | Constraints | Notes |
 |---|---|---|---|---|
 | `queryType` | String | yes | `"tag"` \| `"keyword"` | Determines search mode |
-| `tagId` | String (ObjectId) | conditional | required if `queryType === "tag"` | MongoDB ObjectId as string |
-| `keyword` | String | conditional | required if `queryType === "keyword"`; 1–100 chars | Free-text search term |
+| `query` | Object | yes | Nested object | Search input payload |
+| `query.tagId` | String (ObjectId) | conditional | required for tag search when `query.tagNormalizedName` absent | Canonical tag identifier |
+| `query.tagNormalizedName` | String | conditional | required for tag search when `query.tagId` absent | Lowercase+trimmed key; backend resolves to `tagId` |
+| `query.keyword` | String | conditional | required if `queryType === "keyword"`; 1–100 chars | Free-text search term |
 | `filters` | Object | no | Nested object with arrays | Optional filtering criteria |
 | `filters.levels` | Array[String] | no | Enum values from courses collection | Multi-select filter (AND semantics) |
 | `filters.domains` | Array[String] | no | Enum values from courses collection | Multi-select filter (AND semantics) |
-| `filters.additionalTags` | Array[String] | no | Array of ObjectIds (as strings) | Additional tag filters (AND with main tag/keyword) |
-| `sortBy` | String | no | `"relevance"` \| `"alphabetical"` | Default: `"relevance"` for keyword search; `"alphabetical"` for fallback |
-| `page` | Number | no | Integer ≥ 1 | Default: 1; each page contains 20 results per section |
-| `enrolledRoadmapId` | String (ObjectId) | no | Optional; ref: `roadmaps._id` | User's enrolled roadmap ID for "Recommended for You" highlighting |
+| `filters.additionalTagIds` | Array[String] | no | Array of ObjectIds (as strings) | Additional canonical tag filters |
+| `filters.minConfidence` | Number | no | 0–100 | Minimum confidence for matched `Skill.tags` |
+| `sort.by` | String | no | `"relevance"` \| `"alphabetical"` | Default: `"relevance"`; forced `"alphabetical"` in fallback |
+| `sort.order` | String | no | `"asc"` \| `"desc"` | Default: `"desc"` |
+| `pagination.page` | Number | no | Integer ≥ 1 | Default: 1 |
+| `pagination.pageSize` | Number | no | Integer in [1,50] | Default: 20 |
+| `personalization.enrolledRoadmapId` | String (ObjectId) | no | Optional; ref: `roadmaps._id` | User's enrolled roadmap ID for highlighting |
 
 ### Response `200 OK`
 
@@ -61,7 +111,10 @@ Content-Type: application/json
       "level": "Beginner",
       "domain": "Backend",
       "description": "Learn SQL basics and database querying.",
-      "relatedTags": ["#Database", "#SQL"],
+      "matchedTags": [
+        { "tagId": "64f1a2b3c4d5e6f7a8b9c0d1", "normalizedName": "database", "confidence": 92 },
+        { "tagId": "64f1a2b3c4d5e6f7a8b9c0d9", "normalizedName": "sql", "confidence": 90 }
+      ],
       "relatedSkillCount": 8,
       "highlighted": true,
       "highlightReason": "Part of your Backend Developer roadmap"
@@ -73,7 +126,10 @@ Content-Type: application/json
       "level": "Intermediate",
       "domain": "Backend",
       "description": "Master NoSQL databases with MongoDB.",
-      "relatedTags": ["#Database", "#NoSQL"],
+      "matchedTags": [
+        { "tagId": "64f1a2b3c4d5e6f7a8b9c0d1", "normalizedName": "database", "confidence": 88 },
+        { "tagId": "64f1a2b3c4d5e6f7a8b9c0da", "normalizedName": "nosql", "confidence": 86 }
+      ],
       "relatedSkillCount": 6,
       "highlighted": false,
       "highlightReason": null
@@ -87,12 +143,20 @@ Content-Type: application/json
       "difficulty": "Intermediate",
       "duration": "6 months",
       "courseCount": 12,
-      "relatedTags": ["#Database", "#Backend", "#Server"],
+      "matchedTags": [
+        { "tagId": "64f1a2b3c4d5e6f7a8b9c0d1", "normalizedName": "database", "confidence": 91 },
+        { "tagId": "64f1a2b3c4d5e6f7a8b9c0db", "normalizedName": "backend", "confidence": 84 }
+      ],
       "highlightedCourseCount": 3,
       "highlighted": true,
       "highlightReason": "Your enrolled roadmap"
     }
   ],
+  "queryContext": {
+    "queryType": "tag",
+    "input": { "tagNormalizedName": "database" },
+    "resolvedTagId": "64f1a2b3c4d5e6f7a8b9c0d1"
+  },
   "pagination": {
     "currentPage": 1,
     "pageSize": 20,
@@ -106,7 +170,12 @@ Content-Type: application/json
   "appliedFilters": {
     "levels": ["Intermediate"],
     "domains": [],
-    "additionalTags": []
+    "additionalTagIds": [],
+    "minConfidence": 0
+  },
+  "appliedSort": {
+    "by": "relevance",
+    "order": "desc"
   },
   "fallbackMode": false
 }
@@ -118,8 +187,10 @@ Content-Type: application/json
 |---|---|---|
 | `courses` | Array[CourseResult] | List of related courses (max 20 per page); empty if no matches |
 | `roadmaps` | Array[RoadmapResult] | List of related roadmaps (max 20 per page); empty if no matches |
+| `queryContext` | Object | Canonical query context after input normalization |
 | `pagination` | PaginationMeta | Pagination metadata for both sections |
 | `appliedFilters` | Object | Echo of filters sent in request (for UI feedback) |
+| `appliedSort` | Object | Effective sorting strategy used by backend |
 | `fallbackMode` | Boolean | `true` if results served from pre-cached fallback (search index unavailable); `false` if from live index |
 
 **CourseResult fields**:
@@ -128,7 +199,7 @@ Content-Type: application/json
 - `level`: Enum: Beginner, Intermediate, Advanced
 - `domain`: Domain category (Backend, Frontend, Data, etc.)
 - `description`: Short course overview
-- `relatedTags`: Array of tag names matching the search (shows connection)
+- `matchedTags`: Canonical tag metadata array (`tagId`, `normalizedName`, `confidence`)
 - `relatedSkillCount`: Number of skills in this course matching the search
 - `highlighted`: Boolean; `true` if course is part of enrolled roadmap
 - `highlightReason`: String explaining why highlighted
@@ -139,7 +210,7 @@ Content-Type: application/json
 - `difficulty`: Enum: Beginner, Intermediate, Advanced
 - `duration`: Estimated learning duration (e.g., "6 months")
 - `courseCount`: Total courses in this roadmap
-- `relatedTags`: Array of tag names from courses in this roadmap
+- `matchedTags`: Canonical tag metadata aggregated from roadmap courses
 - `highlightedCourseCount`: Number of courses in this roadmap matching the search
 - `highlighted`: Boolean; `true` if this is the user's enrolled roadmap
 - `highlightReason`: String explaining why highlighted
@@ -158,12 +229,9 @@ Content-Type: application/json
 
 | Status | Condition | Response |
 |---|---|---|
-| `400 Bad Request` | `queryType` missing or invalid (not `"tag"` or `"keyword"`)` | `{ "error": "Invalid queryType" }` |
-| `400 Bad Request` | `queryType === "tag"` but `tagId` missing or invalid | `{ "error": "Missing or invalid tagId for tag search" }` |
-| `400 Bad Request` | `queryType === "keyword"` but `keyword` missing or invalid | `{ "error": "Missing or invalid keyword for keyword search" }` |
-| `400 Bad Request` | `page` is < 1 or not an integer | `{ "error": "page must be an integer ≥ 1" }` |
-| `401 Unauthorized` | Missing or expired access token | `{ "error": "Unauthorized" }` |
-| `500 Internal Server Error` | Unexpected DB or index failure | `{ "error": "Search query failed" }` (returns fallback results if available) |
+| `400 Bad Request` | `queryType` missing/invalid, invalid query payload, unresolved/ conflicting tag input, invalid pagination/sort/filter | `{ "error": { "code": "INVALID_INPUT", "message": "Invalid search request", "details": { ... } } }` |
+| `401 Unauthorized` | Missing or expired access token | `{ "error": { "code": "UNAUTHORIZED", "message": "Unauthorized" } }` |
+| `500 Internal Server Error` | Unexpected DB/index/cache failure and no fallback available | `{ "error": { "code": "INTERNAL_ERROR", "message": "Search query failed" } }` |
 
 ### Example requests
 
@@ -174,10 +242,11 @@ curl -X POST http://localhost:4000/api/search/query \
   -H "Content-Type: application/json" \
   -d '{
     "queryType": "tag",
-    "tagId": "64f1a2b3c4d5e6f7a8b9c0d1",
-    "filters": { "levels": ["Intermediate"] },
-    "page": 1,
-    "enrolledRoadmapId": "74f1a2b3c4d5e6f7a8b9c0d2"
+    "query": { "tagNormalizedName": "database" },
+    "filters": { "levels": ["Intermediate"], "minConfidence": 60 },
+    "sort": { "by": "relevance", "order": "desc" },
+    "pagination": { "page": 1, "pageSize": 20 },
+    "personalization": { "enrolledRoadmapId": "74f1a2b3c4d5e6f7a8b9c0d2" }
   }'
 ```
 
@@ -188,14 +257,14 @@ curl -X POST http://localhost:4000/api/search/query \
   -H "Content-Type: application/json" \
   -d '{
     "queryType": "keyword",
-    "keyword": "database",
+    "query": { "keyword": "database" },
     "filters": {
       "levels": ["Intermediate", "Advanced"],
       "domains": ["Backend"],
-      "additionalTags": ["64f1a2b3c4d5e6f..."]
+      "additionalTagIds": ["64f1a2b3c4d5e6f..."]
     },
-    "sortBy": "alphabetical",
-    "page": 1
+    "sort": { "by": "alphabetical", "order": "asc" },
+    "pagination": { "page": 1, "pageSize": 20 }
   }'
 ```
 
@@ -220,18 +289,21 @@ No query parameters. No request body.
 {
   "tags": [
     {
-      "id": "64f1a2b3c4d5e6f7a8b9c0d1",
-      "name": "#Database",
+      "tagId": "64f1a2b3c4d5e6f7a8b9c0d1",
+      "normalizedName": "database",
+      "displayName": "#Database",
       "count": 42
     },
     {
-      "id": "64f1a2b3c4d5e6f7a8b9c0d2",
-      "name": "#JavaScript",
+      "tagId": "64f1a2b3c4d5e6f7a8b9c0d2",
+      "normalizedName": "javascript",
+      "displayName": "#JavaScript",
       "count": 35
     },
     {
-      "id": "64f1a2b3c4d5e6f7a8b9c0d3",
-      "name": "#Backend",
+      "tagId": "64f1a2b3c4d5e6f7a8b9c0d3",
+      "normalizedName": "backend",
+      "displayName": "#Backend",
       "count": 28
     }
   ],
@@ -259,16 +331,17 @@ No query parameters. No request body.
 | `domains` | Array[String] | Distinct domain values from courses collection |
 
 **TagFilter subtype**:
-- `id`: Tag ID (ObjectId as string)
-- `name`: Tag name (e.g., "#Database")
+- `tagId`: Tag ID (ObjectId as string)
+- `normalizedName`: Canonical key (lowercase + trimmed)
+- `displayName`: UI label (e.g., "#Database")
 - `count`: Number of skills tagged with this tag (optional, for UI badges)
 
 ### Error responses
 
 | Status | Condition | Response |
 |---|---|---|
-| `401 Unauthorized` | Missing or expired access token | `{ "error": "Unauthorized" }` |
-| `500 Internal Server Error` | Unexpected DB failure | `{ "error": "Failed to fetch filters" }` |
+| `401 Unauthorized` | Missing or expired access token | `{ "error": { "code": "UNAUTHORIZED", "message": "Unauthorized" } }` |
+| `500 Internal Server Error` | Unexpected DB failure | `{ "error": { "code": "INTERNAL_ERROR", "message": "Failed to fetch filters" } }` |
 
 ### Example request
 
@@ -324,8 +397,8 @@ No query parameters. No request body.
 
 | Status | Condition | Response |
 |---|---|---|
-| `401 Unauthorized` | Missing or expired access token | `{ "error": "Unauthorized" }` |
-| `500 Internal Server Error` | Unexpected DB failure | `{ "error": "Failed to fetch personalization data" }` |
+| `401 Unauthorized` | Missing or expired access token | `{ "error": { "code": "UNAUTHORIZED", "message": "Unauthorized" } }` |
+| `500 Internal Server Error` | Unexpected DB failure | `{ "error": { "code": "INTERNAL_ERROR", "message": "Failed to fetch personalization data" } }` |
 
 ### Example request
 
@@ -340,7 +413,7 @@ curl -X GET http://localhost:4000/api/search/personalization \
 
 ### Search Engine Failure (Endpoint 1)
 
-If the live search index (MongoDB text index or Elasticsearch) is unavailable:
+If the live search index (MongoDB text index in MVP) is unavailable:
 
 1. The backend catches the index query error
 2. Falls back to the `search_cache` collection (pre-computed fallback data)
@@ -349,7 +422,7 @@ If the live search index (MongoDB text index or Elasticsearch) is unavailable:
 5. Fallback results do **not include personalization highlighting** (limiting to basic discovery)
 
 **Expected client handling**:
-- Disable `sortBy: "relevance"` button when `fallbackMode: true`
+- Disable `sort.by = "relevance"` option when `fallbackMode: true`
 - Show a banner: "Search results are temporarily simplified. Please refresh to update."
 
 ### Filter & Personalization Failure (Endpoints 2 & 3)

--- a/specs/008-advanced-tag-search/data-model.md
+++ b/specs/008-advanced-tag-search/data-model.md
@@ -2,28 +2,45 @@
 
 **Feature**: `008-advanced-tag-search`  
 **Date**: 2026-03-11  
-**Research dependency**: [research.md](research.md) (R-001 to R-007)
+**Research dependency**: [research.md](research.md) (R-001 to R-008)
 
 ---
 
-## Entity: SearchQuery Request
+## Entity: SearchQueryRequest
 
-**Purpose**: Frontend → Backend request payload for tag-based and keyword-based search.
+**Purpose**: Frontend → Backend request payload for tag-based and keyword-based search, with canonical normalization before execution.
 
 ### Schema
 
 | Field | Type | Required | Default | Constraints | Notes |
 |---|---|---|---|---|---|
-| `queryType` | String (enum) | yes | — | `"tag"` \| `"keyword"` | Determines which search mode: tag click or keyword search |
-| `tagId` | String (ObjectId) | conditional | — | required if `queryType === "tag"`; ref: `skills.tags` | Tag to search for (e.g., #Database) |
-| `keyword` | String | conditional | — | required if `queryType === "keyword"`; 1–100 chars | Free-text search term (e.g., "SQL", "Database") |
-| `filters` | Object | no | `{}` | Nested object | Combined filter criteria |
-| `filters.levels` | Array[String] | no | `[]` | Enum values from `courses.level` | Level filter (Beginner, Intermediate, Advanced) |
-| `filters.domains` | Array[String] | no | `[]` | Enum values from `courses.domain` | Domain filter (Backend, Frontend, Data, etc.) |
-| `filters.additionalTags` | Array[String] | no | `[]` | Array of TagIds (ObjectId) | Additional tags to further narrow results (AND semantics) |
-| `sortBy` | String (enum) | no | `"relevance"` | `"relevance"` \| `"alphabetical"` | Result sorting strategy |
-| `page` | Number | no | `1` | Integer ≥ 1 | Page number for pagination (20 results per page) |
-| `enrolledRoadmapId` | String (ObjectId) | no | null | Optional ref: `roadmaps._id` | User's enrolled roadmap ID for personalization highlighting |
+| `queryType` | String (enum) | yes | — | `"tag"` \| `"keyword"` | Determines search mode |
+| `query` | Object | yes | — | nested | Query payload |
+| `query.tagId` | String (ObjectId) | conditional | null | required for tag search when `query.tagNormalizedName` is absent | Canonical tag identity (preferred) |
+| `query.tagNormalizedName` | String | conditional | null | lowercase, trimmed; required for tag search when `query.tagId` is absent | Human-entered/tag-cloud key; backend resolves to canonical `tagId` |
+| `query.keyword` | String | conditional | null | required if `queryType === "keyword"`; 1–100 chars | Free-text term |
+| `filters` | Object | no | `{}` | nested object | AND semantics across dimensions |
+| `filters.levels` | Array[String] | no | `[]` | enum values from `courses.level` | Course level filter |
+| `filters.domains` | Array[String] | no | `[]` | enum values from `courses.domain` | Course domain filter |
+| `filters.additionalTagIds` | Array[String] | no | `[]` | ObjectIds | Additional canonical tags |
+| `filters.minConfidence` | Number | no | `0` | 0–100 | Minimum `Skill.tags.confidence` for matched tags |
+| `sort` | Object | no | `{ "by": "relevance", "order": "desc" }` | nested | Sorting contract |
+| `sort.by` | String (enum) | no | `"relevance"` | `"relevance"` \| `"alphabetical"` | In fallback mode, backend forces `alphabetical` |
+| `sort.order` | String (enum) | no | `"desc"` | `"asc"` \| `"desc"` | `relevance` generally uses `desc` |
+| `pagination` | Object | no | `{ "page": 1, "pageSize": 20 }` | nested | Pagination contract |
+| `pagination.page` | Number | no | `1` | integer ≥ 1 | 1-indexed page number |
+| `pagination.pageSize` | Number | no | `20` | integer 1–50 | Default and recommended = 20 |
+| `personalization` | Object | no | `{}` | nested | Optional personalization payload |
+| `personalization.enrolledRoadmapId` | String (ObjectId) | no | null | ref: `roadmaps._id` | Highlighting hint |
+
+### Canonical normalization rule
+
+- If `queryType = "tag"`, backend MUST resolve input to `resolvedTagId` before query execution.
+- Accepted inputs:
+  - `query.tagId`
+  - `query.tagNormalizedName`
+  - both together (must map to same tag)
+- Conflict or unresolved input returns `INVALID_INPUT`.
 
 ### Example payloads
 
@@ -31,14 +48,20 @@
 ```json
 {
   "queryType": "tag",
-  "tagId": "64f1a2b3c4d5e6f7a8b9c0d1",
+  "query": {
+    "tagNormalizedName": "database"
+  },
   "filters": {
     "levels": ["Intermediate"],
-    "domains": []
+    "domains": [],
+    "additionalTagIds": [],
+    "minConfidence": 60
   },
-  "sortBy": "relevance",
-  "page": 1,
-  "enrolledRoadmapId": "74f1a2b3c4d5e6f7a8b9c0d2"
+  "sort": { "by": "relevance", "order": "desc" },
+  "pagination": { "page": 1, "pageSize": 20 },
+  "personalization": {
+    "enrolledRoadmapId": "74f1a2b3c4d5e6f7a8b9c0d2"
+  }
 }
 ```
 
@@ -46,15 +69,18 @@
 ```json
 {
   "queryType": "keyword",
-  "keyword": "database design",
+  "query": {
+    "keyword": "database design"
+  },
   "filters": {
     "levels": ["Intermediate", "Advanced"],
     "domains": ["Backend", "Data"],
-    "additionalTags": ["64f1a2b3c4d5e6f7a8b9c0d1"]
+    "additionalTagIds": ["64f1a2b3c4d5e6f7a8b9c0d1"],
+    "minConfidence": 70
   },
-  "sortBy": "alphabetical",
-  "page": 2,
-  "enrolledRoadmapId": null
+  "sort": { "by": "alphabetical", "order": "asc" },
+  "pagination": { "page": 2, "pageSize": 20 },
+  "personalization": { "enrolledRoadmapId": null }
 }
 ```
 
@@ -71,7 +97,9 @@
 | `courses` | Array[CourseResult] | Related courses (max 20 per page) |
 | `roadmaps` | Array[RoadmapResult] | Related roadmaps (max 20 per page) |
 | `pagination` | PaginationMeta | Metadata for pagination control |
+| `queryContext` | Object | Canonical query context after normalization |
 | `appliedFilters` | Object | Echo of filters applied (for UI feedback) |
+| `appliedSort` | Object | Effective sort strategy |
 | `fallbackMode` | Boolean | `true` if results served from cache (search index unavailable); `false` if from live index |
 
 ### CourseResult subtype
@@ -84,7 +112,7 @@
 | `level` | String | Enum: Beginner, Intermediate, Advanced |
 | `domain` | String | Domain category (Backend, Frontend, Data, etc.) |
 | `description` | String | Short course description |
-| `relatedTags` | Array[String] | Tags that matched the search (shows why course was returned) |
+| `matchedTags` | Array[SkillTagMatch] | Canonical matched tags from `Skill.tags` (`tagId`, `normalizedName`, `confidence`) |
 | `relatedSkillCount` | Number | Count of skills in this course matching the search filter |
 | `highlighted` | Boolean | `true` if course is part of user's enrolled roadmap (personalization) |
 | `highlightReason` | String | If `highlighted: true`, explain why (e.g., "Part of your Backend Developer roadmap") |
@@ -99,10 +127,18 @@
 | `difficulty` | String | Difficulty level (Beginner, Intermediate, Advanced) |
 | `duration` | String | Estimated duration (e.g., "6 months", "12 weeks") |
 | `courseCount` | Number | Number of courses in this roadmap |
-| `relatedTags` | Array[String] | Tags that matched the search |
+| `matchedTags` | Array[SkillTagMatch] | Canonical matched tags aggregated from roadmap courses |
 | `highlightedCourseCount` | Number | Count of courses in this roadmap that matched the search (shows connection strength) |
 | `highlighted` | Boolean | `true` if this is the user's enrolled roadmap (personalization) |
 | `highlightReason` | String | If `highlighted: true`, explain why (e.g., "Your enrolled roadmap") |
+
+### SkillTagMatch subtype
+
+| Field | Type | Notes |
+|---|---|---|
+| `tagId` | String (ObjectId) | Canonical tag reference |
+| `normalizedName` | String | Canonical tag key (lowercase/trimmed) |
+| `confidence` | Number | Matched confidence (0–100) |
 
 ### PaginationMeta subtype
 
@@ -129,7 +165,10 @@
       "level": "Beginner",
       "domain": "Backend",
       "description": "Learn SQL basics and database querying.",
-      "relatedTags": ["#Database", "#SQL"],
+      "matchedTags": [
+        { "tagId": "64f1a2b3c4d5e6f7a8b9c0d1", "normalizedName": "database", "confidence": 92 },
+        { "tagId": "64f1a2b3c4d5e6f7a8b9c0d9", "normalizedName": "sql", "confidence": 90 }
+      ],
       "relatedSkillCount": 8,
       "highlighted": true,
       "highlightReason": "Part of your Backend Developer roadmap"
@@ -141,7 +180,10 @@
       "level": "Intermediate",
       "domain": "Backend",
       "description": "Master NoSQL databases with MongoDB.",
-      "relatedTags": ["#Database", "#NoSQL"],
+      "matchedTags": [
+        { "tagId": "64f1a2b3c4d5e6f7a8b9c0d1", "normalizedName": "database", "confidence": 88 },
+        { "tagId": "64f1a2b3c4d5e6f7a8b9c0da", "normalizedName": "nosql", "confidence": 86 }
+      ],
       "relatedSkillCount": 6,
       "highlighted": false,
       "highlightReason": null
@@ -155,12 +197,20 @@
       "difficulty": "Intermediate",
       "duration": "6 months",
       "courseCount": 12,
-      "relatedTags": ["#Database", "#Backend", "#Server"],
+      "matchedTags": [
+        { "tagId": "64f1a2b3c4d5e6f7a8b9c0d1", "normalizedName": "database", "confidence": 91 },
+        { "tagId": "64f1a2b3c4d5e6f7a8b9c0db", "normalizedName": "backend", "confidence": 84 }
+      ],
       "highlightedCourseCount": 3,
       "highlighted": true,
       "highlightReason": "Your enrolled roadmap"
     }
   ],
+  "queryContext": {
+    "queryType": "tag",
+    "input": { "tagNormalizedName": "database" },
+    "resolvedTagId": "64f1a2b3c4d5e6f7a8b9c0d1"
+  },
   "pagination": {
     "currentPage": 1,
     "pageSize": 20,
@@ -174,11 +224,29 @@
   "appliedFilters": {
     "levels": ["Intermediate"],
     "domains": [],
-    "additionalTags": []
+    "additionalTagIds": [],
+    "minConfidence": 0
+  },
+  "appliedSort": {
+    "by": "relevance",
+    "order": "desc"
   },
   "fallbackMode": false
 }
 ```
+
+---
+
+## Entity: ErrorResponse
+
+**Purpose**: Standardized non-2xx response envelope shared across search endpoints.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `error` | Object | yes | Error wrapper |
+| `error.code` | String | yes | Stable machine code (`INVALID_INPUT`, `UNAUTHORIZED`, `INTERNAL_ERROR`, etc.) |
+| `error.message` | String | yes | Human-readable message |
+| `error.details` | Object | no | Optional validation/debug metadata |
 
 ---
 
@@ -263,11 +331,11 @@
 | `_id` | ObjectId | Unique skill identifier |
 | `name` | String | Skill name (e.g., "SQL", "REST API Design") |
 | `description` | String | Detailed description (used in full-text search) |
-| `tags` | Array[Object] | Array of tags: `[{ tagId: ObjectId, tagName: String, confidence: Number }]` |
+| `tags` | Array[SkillTag] | Canonical shape from FEAT-006: `[{ tagId: ObjectId, normalizedName: String, confidence: Number }]` |
 | `categoryId` | ObjectId | ref: `skill_categories` (used for Domain filter) |
 | `level` | String | Enum: Beginner, Intermediate, Advanced |
 
-**Index required**: `{ tags: 1, description: "text" }` — for tag matching and full-text search (text index on description). If MongoDB text index is used, this is essential.
+**Index required**: `{'tags.tagId': 1, 'tags.normalizedName': 1, description: 'text', name: 'text'}` — for canonical tag matching + full-text search.
 
 ---
 
@@ -320,10 +388,12 @@ Frontend: POST /api/search/query
         │
         ▼
 Backend: search.controller.js
-        │ Validates payload, calls searchService.executeSearch()
+  │ Validates payload + normalizes query.tagId/query.tagNormalizedName → resolvedTagId
+  │ Calls searchService.executeSearch()
         │
-        ├─── Try: Query MongoDB text index or Elasticsearch
+  ├─── Try: Query MongoDB text index
         │         • Build filter query from criteria
+  │         • Filter canonical Skill.tags by tagId/normalizedName/confidence
         │         • Fetch courses and roadmaps
         │         • Deduplicate by _id (Map/Set)
         │         • Highlight results (if enrolledRoadmapId provided)
@@ -351,10 +421,12 @@ User views results with "Recommended for You" highlights
 ## Constraints & Consistency Rules
 
 1. **Deduplication**: Same course/roadmap must appear only once in results, regardless of how many paths (Tag → Skill → Course) lead to it.
-2. **Pagination**: Page 1 always shows courses 1–20 of total results, not per-section. Same for roadmaps.
-3. **Highlighting logic**: A course is highlighted only if it appears in the roadmap (via `roadmapId.courseIds`) that matches `enrolledRoadmapId`.
-4. **Fallback mode**: When `fallbackMode: true`, sorting is fixed to alphabetical (no relevance scoring available), and highlighting is disabled (no relationship data available).
-5. **Filter consistency**: All three filter types (Tag, Level, Domain) use AND semantics — a result must match all selected filters.
+2. **Input normalization**: Tag search is executed only after `tagId` canonicalization succeeds.
+3. **Pagination**: `pagination.page` and `pagination.pageSize` are validated before execution.
+4. **Highlighting logic**: A course is highlighted only if it appears in the roadmap (via `roadmapId.courseIds`) that matches `enrolledRoadmapId`.
+5. **Fallback mode**: When `fallbackMode: true`, sorting is fixed to alphabetical (no relevance scoring available), and highlighting is disabled (no relationship data available).
+6. **Filter consistency**: Tag/Level/Domain/additional tags/min confidence use AND semantics.
+7. **Error contract**: Non-2xx responses always use `ErrorResponse` envelope.
 
 ---
 
@@ -363,3 +435,4 @@ User views results with "Recommended for You" highlights
 - **At 10K skills**: MongoDB text index performs well (<100ms query time).
 - **At 50K skills**: Re-evaluate and consider migrating to Elasticsearch. Text index latency may exceed 500ms target. Update `search.index.js` to support both backends via abstraction.
 - **Fallback cache size**: At 50K skills, fallback document may exceed BSON 16MB limit. Consider splitting into multiple documents or archiving older cache data.
+- **MVP infra decision**: MongoDB text index is finalized; there is no undecided search backend in current scope.

--- a/specs/008-advanced-tag-search/plan.md
+++ b/specs/008-advanced-tag-search/plan.md
@@ -5,13 +5,13 @@
 
 ## Summary
 
-Build an advanced search and discovery system that allows learners to explore the UETCompass ecosystem through AI-generated tags, enabling both tag-based click discovery and keyword-based search. The system traverses the relationship graph (Tag → Skill → Course → Roadmap) to return semantically related courses and roadmaps, organized into two distinct sections with 20-result pagination and relevance-based sorting. Search results highlight courses/roadmaps aligned with the user's current track as "Recommended for You". The search layer uses an indexed query (Elasticsearch or MongoDB full-text index) with graceful degradation to pre-cached fallback results if the search index becomes unavailable. Frontend supports filter combinations (Tag + Level + Domain) and result sorting without requerying. Personalization data (user's enrolled roadmap) is fetched once per session and reused across search instances.
+Build an advanced search and discovery system that allows learners to explore the UETCompass ecosystem through AI-generated tags, enabling both tag-based click discovery and keyword-based search. The system traverses the relationship graph (Tag → Skill → Course → Roadmap) to return semantically related courses and roadmaps, organized into two distinct sections with 20-result pagination and relevance-based sorting. Search results highlight courses/roadmaps aligned with the user's current track as "Recommended for You". The search layer is locked to MongoDB native text index for MVP, with graceful degradation to pre-cached fallback results if the index becomes unavailable. Search input accepts `tagId` or `tagNormalizedName`, then normalizes to canonical `tagId` before execution. Frontend supports filter combinations (Tag + Level + Domain) and result sorting without changing search intent. Personalization data (user's enrolled roadmap) is fetched once per session and reused across search instances.
 
 ## Technical Context
 
 **Language/Version**: JavaScript — Node.js 20 LTS (backend), React 18 (frontend)
 **Primary Dependencies**:
-- Backend: Express.js, Mongoose 8, `elasticsearch` or built-in MongoDB `text` index (decided during Phase 1 research)
+- Backend: Express.js, Mongoose 8, MongoDB native `text` index (`$text`, `$meta: "textScore"`)
 - Frontend: React 18, React Router v6, React Query (for caching search results)
 
 **Storage**: MongoDB Atlas free tier — `skills` collection (with AI-generated tags), `courses` collection, `roadmaps` collection (all pre-existing), `search_cache` collection (for graceful degradation fallback data); user enrollment data read from `student_profiles.enrolledRoadmap`
@@ -19,7 +19,7 @@ Build an advanced search and discovery system that allows learners to explore th
 **Target Platform**: Backend → Render (Node.js web service, free tier); Frontend → Vercel (React SPA)
 **Project Type**: Web application — React SPA + Node.js/Express REST API (modular monolith)
 **Performance Goals**: 500ms p95 latency for search queries on 10,000-skill dataset; fallback results available within 100ms when index unavailable
-**Constraints**: No Redis (MongoDB-only search index or Elasticsearch); free tier search solution preferred; must support future scaling to 50,000 skills with review of optimization strategy
+**Constraints**: No Redis; MongoDB-only search index in MVP; canonical SkillTag contract shared with FEAT-006; must support future scaling to 50,000 skills with optimization review
 **Scale/Scope**: All authenticated UET learners can search; discovery features available to all without per-user restrictions (but personalization highlighting for enrolled users)
 
 ## Constitution Check
@@ -29,7 +29,7 @@ Build an advanced search and discovery system that allows learners to explore th
 - [x] **Modular Monolithic**: All search logic isolated in `backend/src/modules/search/`. Cross-module integration points: (1) reads from `skill` module's tags via Skill schema reference, (2) reads from `course` and `roadmap` modules' schemas, (3) calls `studentProfileService.getUserEnrolledRoadmap(userId)` via service layer — no direct cross-module imports. Module boundary strictly respected.
 - [x] **UET-First**: Feature scope is exclusively for UET learners discovering UET curriculum via UET-generated tags. Tag schema and filter options (Level, Domain) are UET-specific concepts. No abstraction for other universities.
 - [x] **Privacy**: Feature does not collect or store any student credentials or sensitive personal data. User's enrolled roadmap ID is read for personalization highlighting only — this data is already stored and managed by the onboarding/profile feature. No new credential handling introduced.
-- [x] **AI-Assisted**: Tag content is produced by Feature 006 (AI Auto-Tagging System) and consumed (not generated) by this search feature. The search system does not call Gemini — it only queries and organizes existing tags. Relevance sorting may optionally use Gemini for ranking, but that is Phase 2+ scope. Current MVP uses TF-IDF or Elasticsearch relevance scoring.
+- [x] **AI-Assisted**: Tag content is produced by Feature 006 (AI Auto-Tagging System) and consumed (not generated) by this search feature. The search system does not call Gemini — it only queries and organizes existing tags. Current MVP uses MongoDB `textScore` (BM25) with canonical `Skill.tags` metadata.
 - [x] **Test What Matters**: Unit tests mandatory for: deduplication logic (handling Tag→Skill→Course→Roadmap multi-path traversal), filter combination logic (AND/OR semantics), fallback/graceful-degradation activation, and pagination boundary cases. Search index setup and query mechanics can be integration-tested; unit tests focus on business logic (dedup, filtering, fallback rules).
 
 ## Project Structure
@@ -60,11 +60,13 @@ backend/
 │   │   │   ├── search.controller.js      # Express handlers: POST /search/query, GET /search/filters
 │   │   │   ├── search.routes.js          # Route definitions + auth middleware
 │   │   │   ├── search.service.js         # Query execution, deduplication, pagination, sorting
-│   │   │   ├── search.queryBuilder.js    # Build Mongoose queries or Elasticsearch DSL from filters
+│   │   │   ├── search.queryBuilder.js    # Build canonical Mongoose queries from normalized input + filters
+│   │   │   ├── search.normalizer.js      # Resolve tagNormalizedName/tagId -> canonical tagId
 │   │   │   ├── search.dedup.js           # Deduplication logic: handle multi-path Tag→Skill→Course/Roadmap
 │   │   │   ├── search.cache.js           # Cache/fallback management, seed initial cache
-│   │   │   ├── search.index.js           # Search index initialization (Mongoose text index or Elasticsearch)
+│   │   │   ├── search.index.js           # MongoDB text index initialization and health checks
 │   │   │   ├── search.personalization.js # Load user's enrolled roadmap, highlight logic
+│   │   │   ├── search.validation.js      # Request contract validation + canonical error mapping
 │   │   │   └── search.logger.js          # Query logging + performance metrics
 │   │   ├── skill/                         # Referenced (read-only) — provide tags
 │   │   │   └── skill.model.js            # Skill schema with tags array + confidence
@@ -80,9 +82,11 @@ backend/
         └── search/
             ├── dedup.test.js             # Deduplication: multi-path traversal, duplicate trimming
             ├── filter.test.js            # Filter combinations: Tag AND Level, inclusive/exclusive
+            ├── normalizer.test.js        # tagId/tagNormalizedName normalization and conflict validation
             ├── pagination.test.js        # Pagination boundaries, page overflow, empty pages
             ├── fallback.test.js          # Graceful degradation: index unavailable → cache served
-            └── personalization.test.js   # Enrolled roadmap highlighting, missing enrollment
+            ├── personalization.test.js   # Enrolled roadmap highlighting, missing enrollment
+            └── errors.test.js            # Standardized error envelope and error codes
 ```
 
 #### Frontend
@@ -109,24 +113,8 @@ frontend/
 │       └── SearchResultBadge.jsx         # "Recommended for You" badge component (reusable)
 ```
 
-**Structure Decision**: Option 2 — Web application. Modular monolith backend; all search logic isolated in `modules/search/`. Reads (no writes) from existing `skill`, `course`, `roadmap` modules via Mongoose schema references. Frontend uses feature-folder structure mirroring backend module. React Query handles client-side search result caching and pagination state.
-<!--
-  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
-  for this feature. Delete unused options and expand the chosen structure with
-  real paths (e.g., apps/admin, packages/something). The delivered plan must
-  not include Option labels.
--->
+**Structure Decision**: Web application (React SPA + Node/Express modular monolith). All search logic remains isolated in `modules/search/`. Reads (no writes) from existing `skill`, `course`, `roadmap` modules via Mongoose references and canonical `Skill.tags` shape shared with FEAT-006.
 
-```text
-# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
-src/
-├── models/
-├── services/
-├── cli/
-└── lib/
-
-tests/
-├── contract/
 ## Complexity Tracking
 
 No Constitution violations — complexity tracking table not required.
@@ -135,22 +123,17 @@ No Constitution violations — complexity tracking table not required.
 
 ## Phase 0: Research & Technical Decisions
 
-### Key Unknowns to Resolve
+### Technical Decisions Locked
 
-1. **Search Index Technology**: MongoDB native text index vs. Elasticsearch vs. in-memory Filter? (Trade-off: simplicity vs. performance)
-2. **Deduplication Algorithm**: Efficient dedup for Tag→Skill→Course/Roadmap multi-path traversal on 10K-50K scale
-3. **Personalization Data Flow**: How/when to load user's enrolled roadmap for highlighting (cache in session vs. fetch per-query)
-4. **Relevance Scoring Strategy**: TF-IDF, Elasticsearch BM25, or simple match-count for MVP?
-5. **Fallback Cache Refresh**: How often to rebuild pre-cached fallback data (daily? on-demand? event-driven from FEAT-006)?
+1. **Search Index Technology**: MongoDB native text index is locked for MVP. Elasticsearch is deferred to a later phase.
+2. **Deduplication Algorithm**: Set/Map-based deduplication across Tag→Skill→Course→Roadmap is locked.
+3. **Personalization Data Flow**: Fetch enrolled roadmap once per session and cache via React Query.
+4. **Relevance Scoring Strategy**: MongoDB `textScore` (BM25) is locked for MVP.
+5. **Fallback Cache Refresh**: Startup seed + scheduled refresh every 6 hours is locked.
+6. **Input Canonicalization**: Accept `tagId`/`tagNormalizedName`; normalize to canonical `tagId` before query execution.
+7. **Error Contract**: Standard envelope `{ error: { code, message, details? } }` is locked for all endpoints.
 
-### Research Tasks
-
-- Research MongoDB text indexing vs. Elasticsearch for 50K+ scale
-- Benchmark deduplication algorithms on mock graphs (1K, 10K, 50K edges)
-- Design graceful degradation fallback (cache structure, refresh strategy)
-- Survey relevance scoring approaches compatible with free tier
-
-**Research Output**: `research.md` — technology choices locked, rationale documented
+**Research Output**: `research.md` — decisions finalized (no unresolved infrastructure choice in MVP)
 
 ---
 
@@ -159,7 +142,7 @@ No Constitution violations — complexity tracking table not required.
 ### Deliverables
 
 1. **data-model.md**: 
-   - SearchQuery, SearchResponse, PaginationMeta schemas
+   - SearchQueryRequest, SearchResponse, PaginationMeta, ErrorResponse schemas
    - Tag-Skill-Course-Roadmap relationship documentation
    - SearchCache schema (for fallback data)
 
@@ -175,7 +158,7 @@ No Constitution violations — complexity tracking table not required.
 
 4. **Agent Context Update**:
    - Run `.specify/scripts/powershell/update-agent-context.ps1 -AgentType copilot`
-   - Add search index technology choice (Elasticsearch or MongoDB text) to context
+   - Add finalized search index technology choice (MongoDB text index for MVP) to context
    - Document Mongoose query patterns for multi-table traversal
 
 ---

--- a/specs/008-advanced-tag-search/research.md
+++ b/specs/008-advanced-tag-search/research.md
@@ -10,13 +10,14 @@
 
 **Question**: Should we use MongoDB's built-in text index or deploy Elasticsearch for the search layer? Trade-off: simplicity vs. performance and scalability.
 
-**Decision**: **MongoDB native text index** for MVP (0–10K skills). Switch to Elasticsearch as an optional Phase 2 optimization when approaching 50K skills.
+**Decision (LOCKED)**: **MongoDB native text index** for MVP (0–10K skills). Elasticsearch is explicitly deferred to a later phase when approaching 50K skills.
 
 **Rationale**:
 - **Simplicity**: MongoDB text index is included free on Atlas M0. Zero infrastructure cost. One less service to manage and monitor in a resource-constrained team.
-- **MVP performance**: MongoDB text index with proper indexing on `skills.tags` and `skills.description` achieves <500ms p95 latency for 10K-skill dataset (Atlas benchmark: single-field text query returns in 20–100ms).
+- **MVP performance**: MongoDB text index with proper indexing on canonical tag/search fields (`skills.tags.tagId`, `skills.tags.normalizedName`, `skills.description`) achieves <500ms p95 latency for 10K-skill dataset (Atlas benchmark: single-field text query returns in 20–100ms).
 - **Graceful degradation built-in**: MongoDB query is already in the code path. When index is unavailable, fallback to pre-computed cache automatically.
 - **Future path**: When data grows to 50K+ skills, re-evaluate. Elasticsearch can be bolted on in Phase 2 without changing the query interface (query builder abstraction hides the backend).
+- **No undecided infrastructure in MVP**: Search backend choice is finalized for implementation.
 
 **Performance estimate** (MongoDB M0 text index):
 - 10K skills, 2–4 tags per skill: 20ms query time (indexed, cached)
@@ -49,7 +50,9 @@
 
 ```js
 // 1. Find skills with tag
-const skills = await Skill.find({ tags: { $in: [tagId] } });
+const skills = await Skill.find({
+  tags: { $elemMatch: { tagId, confidence: { $gte: minConfidence } } },
+});
 const skillIds = skills.map(s => s._id);
 
 // 2. Find courses referencing those skills
@@ -64,7 +67,7 @@ courses.forEach(course => {
 const roadmapMap = new Map(); // roadmapId -> { roadmap, courseIds }
 const roadmaps = await Roadmap.find({ courseIds: { $in: Array.from(courseMap.keys()) } });
 roadmaps.forEach(roadmap => {
-  const relatedCourseIds = roadmap.courseIds.filter(id => courseMap.has(id));
+  const relatedCourseIds = roadmap.courseIds.filter(id => courseMap.has(id.toString()));
   roadmapMap.set(roadmap._id.toString(), { roadmap, courseIds: relatedCourseIds });
 });
 
@@ -174,9 +177,9 @@ async function rebuildSearchCache() {
   const allSkills = await Skill.find({ tags: { $exists: true, $ne: [] } }).lean();
   allSkills.forEach(skill => {
     skill.tags.forEach(tag => {
-      if (!tagCourseMap[tag._id]) tagCourseMap[tag._id] = new Set();
+      if (!tagCourseMap[tag.tagId]) tagCourseMap[tag.tagId] = new Set();
       // Add courses that reference this skill
-      skill.courseIds?.forEach(cid => tagCourseMap[tag._id].add(cid));
+      skill.courseIds?.forEach(cid => tagCourseMap[tag.tagId].add(cid));
     });
   });
 
@@ -207,7 +210,7 @@ setInterval(rebuildSearchCache, SEARCH_CACHE_REFRESH_INTERVAL_MINUTES * 60 * 100
 POST /api/search/query
   ↓
 try {
-  Results ← query indexed search (Mongoose text index or Elasticsearch)
+  Results ← query indexed search (MongoDB text index)
 } catch (err) {
   LogError(err)
   Results ← lookup from search_cache collection (alphabetical, no personalization)
@@ -227,6 +230,7 @@ Return results (either live or fallback)
 | Component | Technology | Version | Rationale |
 |---|---|---|---|
 | **Search Index** | MongoDB native text index | Atlas M0 | Free, built-in, sufficient for 10K skills |
+| **Input normalization** | Canonical tag resolver (`tagId`/`tagNormalizedName` -> `resolvedTagId`) | Node.js service layer | Deterministic query identity and FE flexibility |
 | **Deduplication** | JavaScript (Map/Set) | ES6+ | O(1) lookup, scales to 50K |
 | **Personalization** | React Query + session storage | react-query v5 | Already in project; efficient caching |
 | **Scoring** | MongoDB BM25 (`textScore`) | native | Built-in, no custom implementation needed |
@@ -234,14 +238,37 @@ Return results (either live or fallback)
 
 ---
 
-## R-006: Multi-Dimensional Filtering — How to combine Tag + Level + Domain filters
+## R-006: Search Input Canonicalization — `tagId` vs `tagNormalizedName`
+
+**Question**: FE should support search input from either known tag IDs or normalized tag names. How do we keep backend queries deterministic and indexed?
+
+**Decision**: Accept both `query.tagId` and `query.tagNormalizedName`, then normalize to canonical `resolvedTagId` before executing any tag search.
+
+**Normalization rules**:
+1. If only `tagId` exists: validate and use directly.
+2. If only `tagNormalizedName` exists: normalize (trim + lowercase), lookup in `tags.normalizedName`, resolve `_id`.
+3. If both exist: they must resolve to the same tag.
+4. If unresolved/conflicting: return `INVALID_INPUT` and skip query execution.
+
+**Rationale**:
+- Supports both click-flow and manual/tag-text input.
+- Keeps query planner stable by searching primarily on canonical `tagId`.
+- Aligns with FEAT-006 canonical data (`Tag.normalizedName` unique, `Skill.tags.tagId`).
+
+**Alternatives considered**:
+- Search directly by `tagNormalizedName` only: simpler but weaker identity guarantees. Rejected.
+- Require `tagId` only: strict but harms UX for typed tag interactions. Rejected.
+
+---
+
+## R-007: Multi-Dimensional Filtering — How to combine Tag + Level + Domain filters
 
 **Question**: Users can apply multiple filters simultaneously: Tag + Level + Domain. How are these combined? (AND vs. OR semantics)
 
 **Decision**: **AND semantics**: A course must match ALL chosen filters.
 
 **Query logic**:
-- Tag filter: `skills.tags: { $in: [selectedTagIds] }` — course has at least one selected tag
+- Tag filter: `skills.tags.tagId: { $in: [selectedTagIds] }` — course has at least one selected tag
 - Level filter: `level: { $in: [selectedLevels] }` — course level is in the selected list
 - Domain filter: `domain: { $in: [selectedDomains] }` — course domain is in the selected list
 
@@ -251,7 +278,11 @@ Return results (either live or fallback)
 const query = {};
 
 if (selectedTagIds.length > 0) {
-  query['skills.tags._id'] = { $in: selectedTagIds };
+  query['skills.tags.tagId'] = { $in: selectedTagIds };
+}
+
+if (minConfidence > 0) {
+  query['skills.tags.confidence'] = { $gte: minConfidence };
 }
 
 if (selectedLevels.length > 0) {
@@ -275,7 +306,7 @@ const results = await Course.find(query);
 
 ---
 
-## R-007: Filter Discovery Endpoint — How to fetch available filter values
+## R-008: Filter Discovery Endpoint — How to fetch available filter values
 
 **Question**: The frontend FilterBar needs to populate dropdowns with available Level values, Domain values, and Tag list. Should these be pre-computed or fetched on every page load?
 
@@ -291,8 +322,8 @@ const results = await Course.find(query);
 ```json
 {
   "tags": [
-    { "id": "...", "name": "#Database", "count": 42 },
-    { "id": "...", "name": "#JavaScript", "count": 35 },
+    { "tagId": "...", "normalizedName": "database", "displayName": "#Database", "count": 42 },
+    { "tagId": "...", "normalizedName": "javascript", "displayName": "#JavaScript", "count": 35 },
     ...
   ],
   "levels": ["Beginner", "Intermediate", "Advanced"],

--- a/specs/008-advanced-tag-search/spec.md
+++ b/specs/008-advanced-tag-search/spec.md
@@ -2,7 +2,8 @@
 
 **Feature Branch**: `008-advanced-tag-search`  
 **Created**: March 11, 2026  
-**Status**: Draft  
+**Updated**: March 14, 2026  
+**Status**: Draft (refined with canonical schema)  
 **Input**: User description: "Advanced Tag-Based Search (feat-advanced-search) - System for advanced search allowing users to discover the ecosystem through AI-generated tags, creating multi-dimensional connections between Roadmap, Course, and Skill. UX flow: Users click on tag #Database -> system shows related courses (SQL, NoSQL) -> displays related roadmaps (Backend Developer, Data Engineer). Acceptance criteria: 2 sections display (related courses and related roadmaps), query latency <500ms for 10,000 skills, support combined filters (Tag + Level)."
 
 ## Clarifications
@@ -14,6 +15,13 @@
 - Q3: Future Scale Expectations → A: Design for up to 50,000 skills in next year
 - Q4: Search Access Control & Permissions → C: Personalization-aware - show all available plus highlight relevant for user's current track
 - Q5: Search Index Failure Handling → A: Graceful degradation - serve cached/pre-filtered results if search index fails; degrade to basic listing without personalization
+
+### Session 2026-03-14 (canonical alignment)
+
+- Q6: Tag search input format → A: Accept both `tagId` and `tagNormalizedName`; backend resolves to canonical `tagId` before query execution.
+- Q7: Skill tag schema source of truth → A: Use Feature 006 canonical `Skill.tags[] = { tagId, normalizedName, confidence }` without local schema variants.
+- Q8: Search infrastructure MVP → A: Lock to MongoDB native text index for MVP; Elasticsearch is explicitly deferred to a future phase.
+- Q9: Contract style → A: Standardize filter/sort/pagination/error contracts into explicit nested objects with a common error envelope.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -96,6 +104,8 @@ As a system administrator, I want search queries to complete quickly even with l
 
 ### Edge Cases
 
+- What if both `tagId` and `tagNormalizedName` are sent but map to different tags? Return `INVALID_INPUT` and skip search execution.
+- What if `tagNormalizedName` cannot resolve to any canonical Tag entry? Return `INVALID_INPUT` with actionable message.
 - What if a tag has no associated courses? System should handle gracefully by showing empty "Related Courses" section.
 - What if a course is associated with multiple skill tags? System should avoid duplicate course entries in results.
 - What if search/filter combinations return 0 results? System should clearly indicate no results found and suggest alternatives.
@@ -107,17 +117,20 @@ As a system administrator, I want search queries to complete quickly even with l
 ### Functional Requirements
 
 - **FR-001**: System MUST provide tag-based search where users can click a tag to see all related courses and roadmaps.
-- **FR-002**: System MUST provide keyword-based search to find courses and roadmaps by text search (searching tag names, course names, roadmap titles, and descriptions).
+- **FR-002**: System MUST provide keyword-based search to find courses and roadmaps by text search (searching canonical tag names, course names, roadmap titles, and descriptions).
 - **FR-003**: System MUST organize search results into two distinct sections: "Related Courses" and "Related Roadmaps".
-- **FR-004**: System MUST display skill tags within course and roadmap results to show the connection.
-- **FR-005**: System MUST support combined filtering with multiple criteria (e.g., Tag + Skill Level + Domain).
+- **FR-004**: System MUST expose matched tag metadata in results using canonical shape from Feature 006 (`tagId`, `normalizedName`, `confidence`).
+- **FR-005**: System MUST support combined filtering with multiple criteria (primary tag/keyword + additional tags + level + domain) using AND semantics.
 - **FR-006**: System MUST implement efficient querying across the Tag -> Skill -> Course -> Roadmap relationship model.
 - **FR-007**: System MUST prevent duplicate courses/roadmaps in result sets even when reached through multiple skills/tags.
 - **FR-008**: System MUST handle cases with no results by clearly indicating this to the user.
-- **FR-009**: System MUST support result sorting with relevance-based sorting as default; users MUST be able to switch to alphabetical sorting.
-- **FR-010**: System MUST paginate search results with 20 results per page; users MUST be able to navigate between pages.
+- **FR-009**: System MUST support sorting contract with default relevance and optional alphabetical ordering.
+- **FR-010**: System MUST paginate search results with contract `{ page, pageSize }` and default `pageSize = 20`.
 - **FR-011**: System MUST show all available courses and roadmaps in search results; results relevant to the user's current track or enrolled roadmap MUST be highlighted or visually distinguished as "Recommended for You" or similar indicator.
 - **FR-012**: System MUST implement graceful degradation: if the search index becomes unavailable, the system MUST serve pre-cached or pre-filtered results (e.g., all courses, all roadmaps, or basic category listings) without personalization rather than returning an error, maintaining discovery functionality at reduced capability.
+- **FR-013**: Search input MUST accept either `tagId` or `tagNormalizedName` (or both if consistent), and backend MUST normalize to canonical `tagId` before querying.
+- **FR-014**: Search module MUST consume canonical `Skill.tags[]` from Feature 006 as read-only source and MUST NOT introduce alternate embedded tag field names.
+- **FR-015**: All API errors MUST use standardized envelope `{ error: { code, message, details? } }`.
 
 ### Non-Functional Requirements
 
@@ -130,7 +143,8 @@ As a system administrator, I want search queries to complete quickly even with l
 ### Key Entities *(include if feature involves data)*
 
 - **Tag**: Classification label created by AI auto-tagging system (e.g., #Database, #JavaScript, #Intermediate).
-- **Skill**: Represents a competency; associated with one or more tags.
+- **SkillTag**: Canonical embedded metadata in `Skill.tags[]` (`tagId`, `normalizedName`, `confidence`).
+- **Skill**: Represents a competency; associated with one or more canonical `SkillTag` entries.
 - **Course**: Learning module containing multiple skills and tagged with relevant topics.
 - **Roadmap**: Learning path containing multiple courses, representing a career/specialization trajectory.
 - **SearchResult**: Container for displaying related courses and roadmaps with their associated skills and tags.
@@ -145,14 +159,16 @@ As a system administrator, I want search queries to complete quickly even with l
 - Support for at least 3 independent filter dimensions (Tag, Level, Domain minimum).
 - Search results pagination with 20 results per page, supporting unlimited result set sizes.
 - Users can switch between relevance and alphabetical sorting without rerunning search.
+- 100% of invalid inputs return standardized error envelope with stable `error.code`.
 
 ## Assumptions
 
 - AI auto-tagging system (FEAT-006) is available and providing tag data.
+- Canonical tag metadata shape from FEAT-006 is available as `Skill.tags[] = { tagId, normalizedName, confidence }`.
 - Courses and Roadmaps are already created with proper relationships to Skills.
 - User skills/level data is available for filtering if personalization is needed (though not required for MVP).
 - User's enrolled roadmap or current track information is available in the system for personalization highlighting.
-- Search will be performed against in-memory search index or optimized database queries.
+- Search is implemented on MongoDB native text index for MVP; Elasticsearch is deferred.
 - Tag and Skill data is relatively stable (not rapidly changing during search execution).
 - System will scale to support up to 50,000 skills within the next year; current design optimized for up to 10,000 skills with plan for optimization review at 50K scale.
 
@@ -160,6 +176,6 @@ As a system administrator, I want search queries to complete quickly even with l
 
 - AI Auto-Tagging System (FEAT-006) for providing skill tags.
 - Existing Course and Roadmap data models.
-- Search indexing infrastructure (Elasticsearch, Solr, database indexes, or similar).
+- MongoDB Atlas text index infrastructure.
 - Frontend UI components for search forms and result display.
 - Query optimization and performance monitoring tools.


### PR DESCRIPTION
Refine feature 008 documentation end-to-end to match canonical tagging/search contracts and remove remaining ambiguity in technical decisions.

Detailed changes:

- spec.md

  * Added 2026-03-14 clarification set: dual tag input (tagId/tagNormalizedName), canonical Skill.tags usage, locked Mongo text index MVP, standardized contracts.

  * Added FR-013..FR-015 for input normalization, canonical Skill.tags consumption, and unified error envelope.

  * Updated assumptions/dependencies to reflect MongoDB text index as finalized MVP infrastructure.

  * Expanded edge cases for conflicting/unresolved tag normalization behavior.

- plan.md

  * Locked technical stack to MongoDB native text index + textScore (BM25) for MVP; Elasticsearch deferred.

  * Added search.normalizer.js and search.validation.js to planned backend structure.

  * Added unit test coverage entries for normalizer and error-envelope behavior.

  * Removed stale/placeholder structure block and converted Phase 0 into explicit locked decisions.

- data-model.md

  * Reworked request model to canonical SearchQueryRequest with nested query/filters/sort/pagination/personalization objects.

  * Added canonical normalization rule to resolve tag inputs into resolvedTagId before execution.

  * Replaced relatedTags with canonical matchedTags (tagId, normalizedName, confidence) in result entities.

  * Added ErrorResponse model and standardized consistency rules including error contract + normalization constraints.

  * Synced Skill.tags reference fields and required index notes with FEAT-006 canonical shape.

- contracts/rest-api.md

  * Standardized POST /api/search/query payload to nested query/filters/sort/pagination/personalization contract.

  * Added shared conventions section: canonical tag normalization and common error envelope/codes.

  * Updated response schema with queryContext, appliedSort, and matchedTags canonical metadata.

  * Normalized filters endpoint tag payload to tagId/normalizedName/displayName/count.

  * Unified endpoint error responses to structured error envelope and adjusted fallback UX note to new sort contract.

- research.md

  * Marked MongoDB text index decision as LOCKED for MVP and explicitly removed undecided infra state.

  * Added R-006 for tag input canonicalization strategy and validation rules.

  * Renumbered subsequent decisions (R-007 filtering, R-008 filter discovery).

  * Updated pseudocode and filter/query examples to canonical Skill.tags fields and confidence-aware matching.

  * Extended locked technology table with canonical input normalization component.