### PR TITLE
012 roadmap search page

### DIFF
--- a/backend/src/modules/roadmap/manualRoadmap.service.js
+++ b/backend/src/modules/roadmap/manualRoadmap.service.js
@@ -89,7 +89,7 @@ async function listPublic({ q = '', page = 1, limit = 20 } = {}) {
 async function getPublicPreviewById(roadmapId) {
     return ManualRoadmap.findOne(
         { _id: roadmapId },
-        { title: 1, description: 1, nodes: 1, edges: 1, sharedAt: 1 }
+        { title: 1, description: 1, nodes: 1, edges: 1, yamlCode: 1, sharedAt: 1 }
     ).lean();
 }
 

--- a/frontend/src/features/manual-roadmap/ManualRoadmapPage.jsx
+++ b/frontend/src/features/manual-roadmap/ManualRoadmapPage.jsx
@@ -60,6 +60,7 @@ const MANUAL_ROADMAP_SPLIT_DEFAULT_RATIO = 0.32;
 const MANUAL_ROADMAP_SPLIT_MIN_RATIO = 0.2;
 const MANUAL_ROADMAP_SPLIT_MAX_RATIO = 0.8;
 const MANUAL_ROADMAP_RESIZER_WIDTH = 14;
+const MANUAL_ROADMAP_PREFILL_STORAGE_KEY = 'manualRoadmap.editorPrefill';
 
 function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
@@ -155,6 +156,35 @@ export default function ManualRoadmapPage() {
   const layoutRef = useRef(null);
   const resizeDragRef = useRef({ startX: 0, startRatio: MANUAL_ROADMAP_SPLIT_DEFAULT_RATIO });
   const currentSample = SAMPLE_ROADMAPS.find((sample) => sample.key === selectedSampleKey) || SAMPLE_ROADMAPS[0];
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const serializedPrefill = window.sessionStorage.getItem(MANUAL_ROADMAP_PREFILL_STORAGE_KEY);
+    if (!serializedPrefill) {
+      return;
+    }
+
+    window.sessionStorage.removeItem(MANUAL_ROADMAP_PREFILL_STORAGE_KEY);
+
+    try {
+      const parsedPrefill = JSON.parse(serializedPrefill);
+      const prefillYamlCode = typeof parsedPrefill?.yamlCode === 'string' ? parsedPrefill.yamlCode : '';
+
+      if (!prefillYamlCode.trim()) {
+        return;
+      }
+
+      setSelectedSampleKey('custom');
+      setYamlCode(prefillYamlCode);
+      setApiError('');
+      setSuccessMessage('');
+    } catch {
+      // Ignore malformed prefill payload and keep default editor content.
+    }
+  }, []);
 
   useEffect(() => {
     try {

--- a/frontend/src/features/skill-tree/PublicSkillTreePage.jsx
+++ b/frontend/src/features/skill-tree/PublicSkillTreePage.jsx
@@ -3,7 +3,11 @@ import RoadmapGraphRenderer from '../../shared/RoadmapGraphRenderer';
 import { computeLayoutSafe } from '../../shared/elkLayoutEngine';
 import manualRoadmapApi from '../manual-roadmap/manualRoadmap.api';
 import PublicRoadmapNodePanel from './PublicRoadmapNodePanel';
+import { useNotification } from '../general/NotificationContainer';
 import './skill-tree.css';
+
+const ROADMAP_EDITOR_PREFILL_STORAGE_KEY = 'manualRoadmap.editorPrefill';
+const YAML_MAX_LENGTH = 10 * 1024;
 
 function normalizeNodeState(state) {
   const normalized = String(state || '').trim();
@@ -71,6 +75,7 @@ function normalizePreviewNodes(nodes = []) {
 }
 
 export default function PublicSkillTreePage({ roadmapId = '' }) {
+  const { addNotification } = useNotification();
   const [previewStatus, setPreviewStatus] = useState('loading');
   const [previewData, setPreviewData] = useState(null);
   const [errorMessage, setErrorMessage] = useState('');
@@ -104,6 +109,27 @@ export default function PublicSkillTreePage({ roadmapId = '' }) {
     }
 
     window.location.assign('/');
+  };
+
+  const handleOpenInEditor = () => {
+    const yamlCode = typeof previewData?.yamlCode === 'string' ? previewData.yamlCode : '';
+
+    if (!yamlCode.trim() || yamlCode.length > YAML_MAX_LENGTH) {
+      addNotification('Yaml code không khả dụng.', 'error');
+      return;
+    }
+
+    try {
+      window.sessionStorage.setItem(
+        ROADMAP_EDITOR_PREFILL_STORAGE_KEY,
+        JSON.stringify({ yamlCode, sourceRoadmapId: roadmapId, savedAt: Date.now() })
+      );
+    } catch {
+      addNotification('Không thể tải nội dung YAML vào editor.', 'error');
+      return;
+    }
+
+    window.location.assign('/manual-roadmap');
   };
 
   useEffect(() => {
@@ -225,7 +251,16 @@ export default function PublicSkillTreePage({ roadmapId = '' }) {
           <section className="skill-tree-summary-card" aria-label="Roadmap summary">
             <div className="skill-tree-summary-card__top-row">
               <h2 className="skill-tree-summary-card__title">{previewData?.title || 'Roadmap'}</h2>
-              <button type="button" className="skill-tree-back-button" onClick={handleBack}>Back</button>
+              <div className="skill-tree-summary-card__actions">
+                <button
+                  type="button"
+                  className="skill-tree-edit-button"
+                  onClick={handleOpenInEditor}
+                >
+                  Chỉnh sửa Roadmap
+                </button>
+                <button type="button" className="skill-tree-back-button" onClick={handleBack}>Quay lại</button>
+              </div>
             </div>
             <p className="skill-tree-summary-card__meta">{previewData?.description || 'No description available.'}</p>
           </section>

--- a/frontend/src/features/skill-tree/PublicSkillTreePage.jsx
+++ b/frontend/src/features/skill-tree/PublicSkillTreePage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import RoadmapGraphRenderer from '../../shared/RoadmapGraphRenderer';
 import { computeLayoutSafe } from '../../shared/elkLayoutEngine';
+import { useAuth } from '../../providers/AuthProvider';
 import manualRoadmapApi from '../manual-roadmap/manualRoadmap.api';
 import PublicRoadmapNodePanel from './PublicRoadmapNodePanel';
 import { useNotification } from '../general/NotificationContainer';
@@ -75,6 +76,7 @@ function normalizePreviewNodes(nodes = []) {
 }
 
 export default function PublicSkillTreePage({ roadmapId = '' }) {
+  const { isAuthenticated } = useAuth();
   const { addNotification } = useNotification();
   const [previewStatus, setPreviewStatus] = useState('loading');
   const [previewData, setPreviewData] = useState(null);
@@ -112,6 +114,11 @@ export default function PublicSkillTreePage({ roadmapId = '' }) {
   };
 
   const handleOpenInEditor = () => {
+    if (!isAuthenticated) {
+      addNotification('Vui lòng đăng nhập để chỉnh sửa roadmap.', 'warning');
+      return;
+    }
+
     const yamlCode = typeof previewData?.yamlCode === 'string' ? previewData.yamlCode : '';
 
     if (!yamlCode.trim() || yamlCode.length > YAML_MAX_LENGTH) {

--- a/frontend/src/features/skill-tree/skill-tree.css
+++ b/frontend/src/features/skill-tree/skill-tree.css
@@ -146,6 +146,38 @@ html[data-theme='dark'] .skill-tree-summary-card__meta {
   gap: 12px;
 }
 
+.skill-tree-summary-card__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.skill-tree-edit-button {
+  border: 1px solid #2563eb;
+  background: #2563eb;
+  color: #ffffff;
+  border-radius: 10px;
+  padding: 7px 12px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.skill-tree-edit-button:hover {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+}
+
+html[data-theme='dark'] .skill-tree-edit-button {
+  background: #2b6fd0;
+  border-color: #4b8ef0;
+}
+
+html[data-theme='dark'] .skill-tree-edit-button:hover {
+  background: #2059ad;
+  border-color: #3977d2;
+}
+
 .skill-tree-back-button {
   border: 1px solid #93c5fd;
   background: #ffffff;


### PR DESCRIPTION
Added an edit action to the public skill tree header in [PublicSkillTreePage.jsx](vscode-file://vscode-app/d:/Program%20Files/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
The edit action now checks whether the user is authenticated. If not, it shows a notification asking the user to log in before editing.
If the roadmap has no [yamlCode](vscode-file://vscode-app/d:/Program%20Files/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) or the YAML exceeds 10KB, the existing notification system is used to show an error and block the redirect.
When the roadmap is valid, its YAML is stored temporarily and the app navigates to [/manual-roadmap](vscode-file://vscode-app/d:/Program%20Files/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
The manual roadmap page now reads that temporary payload and pre-fills the YAML editor automatically in [ManualRoadmapPage.jsx](vscode-file://vscode-app/d:/Program%20Files/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
The public preview data now includes [yamlCode](vscode-file://vscode-app/d:/Program%20Files/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so the edit flow has the full YAML source available from the skill tree preview in [manualRoadmap.service.js](vscode-file://vscode-app/d:/Program%20Files/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html).