### PR TITLE
feat(account): add hard-delete account flow with cascade cleanup

### DIFF
--- a/backend/src/modules/account/account.controller.js
+++ b/backend/src/modules/account/account.controller.js
@@ -1,4 +1,5 @@
 const accountService = require('./account.service');
+const { getRefreshCookieOptions } = require('../auth/token.service');
 
 function sendError(res, err) {
   const status = err?.status || 500;
@@ -36,6 +37,16 @@ const accountController = {
   async changePassword(req, res) {
     try {
       const result = await accountService.changePassword(req.user.userId, req.body || {});
+      return res.status(200).json(result);
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+
+  async hardDeleteAccount(req, res) {
+    try {
+      const result = await accountService.hardDeleteAccount(req.user.userId);
+      res.clearCookie('rt', getRefreshCookieOptions());
       return res.status(200).json(result);
     } catch (err) {
       return sendError(res, err);

--- a/backend/src/modules/account/account.routes.js
+++ b/backend/src/modules/account/account.routes.js
@@ -8,6 +8,7 @@ accountRouter.use(requireAccountAccess);
 accountRouter.get('/profile', accountController.getProfile);
 accountRouter.patch('/profile', accountController.patchProfile);
 accountRouter.post('/password/change', accountController.changePassword);
+accountRouter.delete('/hard-delete', accountController.hardDeleteAccount);
 
 module.exports = {
   accountRouter,

--- a/backend/src/modules/account/account.service.js
+++ b/backend/src/modules/account/account.service.js
@@ -1,6 +1,14 @@
 const bcrypt = require('bcryptjs');
 const { User } = require('../auth/user.model');
+const { RefreshToken } = require('../auth/refreshToken.model');
+const { DeletedEmail } = require('../auth/deletedEmail.model');
+const { SecurityAudit } = require('../auth/securityAudit.model');
+const { Notification } = require('../notifications/notification.model');
 const { StudentProfile } = require('../onboarding/onboarding.model');
+const { Roadmap } = require('../roadmap/roadmap.model');
+const { RoadmapProgress } = require('../roadmap/roadmapProgress.model');
+const { ManualRoadmap } = require('../roadmap/manualRoadmap.model');
+const { AccountAuditEvent } = require('./account.model');
 const accountAuditService = require('./accountAudit.service');
 const { resolveEffectiveDisplayName } = require('./identity.policy');
 
@@ -254,9 +262,44 @@ async function changePassword(userId, payload = {}) {
   };
 }
 
+async function hardDeleteAccount(userId) {
+  const user = await User.findById(userId);
+  if (!user) {
+    throw buildError(404, 'NOT_FOUND', 'User not found.');
+  }
+
+  await Promise.all([
+    StudentProfile.deleteMany({ userId }),
+    RefreshToken.deleteMany({ userId }),
+    Notification.deleteMany({ userId }),
+    SecurityAudit.deleteMany({ userId }),
+    AccountAuditEvent.deleteMany({ userId }),
+    RoadmapProgress.deleteMany({ userId }),
+    Roadmap.deleteMany({ userId }),
+    ManualRoadmap.deleteMany({ userId }),
+  ]);
+
+  await User.deleteOne({ _id: userId });
+  await DeletedEmail.updateOne(
+    { email: user.email },
+    {
+      $set: {
+        deletedAt: new Date(),
+      },
+    },
+    { upsert: true }
+  );
+
+  return {
+    code: 'ACCOUNT_DELETED',
+    message: 'Account deleted permanently.',
+  };
+}
+
 module.exports = {
   getProfile,
   updateProfile,
   changePassword,
+  hardDeleteAccount,
   validatePasswordPolicy,
 };

--- a/backend/tests/unit/account/account.hard-delete.test.js
+++ b/backend/tests/unit/account/account.hard-delete.test.js
@@ -1,0 +1,119 @@
+jest.mock('../../../src/modules/auth/user.model', () => ({
+  User: {
+    findById: jest.fn(),
+    deleteOne: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/modules/auth/refreshToken.model', () => ({
+  RefreshToken: {
+    deleteMany: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/modules/auth/deletedEmail.model', () => ({
+  DeletedEmail: {
+    updateOne: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/modules/auth/securityAudit.model', () => ({
+  SecurityAudit: {
+    deleteMany: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/modules/notifications/notification.model', () => ({
+  Notification: {
+    deleteMany: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/modules/onboarding/onboarding.model', () => ({
+  StudentProfile: {
+    deleteMany: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/modules/roadmap/roadmap.model', () => ({
+  Roadmap: {
+    deleteMany: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/modules/roadmap/roadmapProgress.model', () => ({
+  RoadmapProgress: {
+    deleteMany: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/modules/roadmap/manualRoadmap.model', () => ({
+  ManualRoadmap: {
+    deleteMany: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/modules/account/account.model', () => ({
+  AccountAuditEvent: {
+    deleteMany: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/modules/account/accountAudit.service', () => ({
+  emitPasswordChanged: jest.fn(),
+  emitProfileUpdated: jest.fn(),
+}));
+
+const { User } = require('../../../src/modules/auth/user.model');
+const { RefreshToken } = require('../../../src/modules/auth/refreshToken.model');
+const { DeletedEmail } = require('../../../src/modules/auth/deletedEmail.model');
+const { SecurityAudit } = require('../../../src/modules/auth/securityAudit.model');
+const { Notification } = require('../../../src/modules/notifications/notification.model');
+const { StudentProfile } = require('../../../src/modules/onboarding/onboarding.model');
+const { Roadmap } = require('../../../src/modules/roadmap/roadmap.model');
+const { RoadmapProgress } = require('../../../src/modules/roadmap/roadmapProgress.model');
+const { ManualRoadmap } = require('../../../src/modules/roadmap/manualRoadmap.model');
+const { AccountAuditEvent } = require('../../../src/modules/account/account.model');
+const accountService = require('../../../src/modules/account/account.service');
+
+describe('account.service hardDeleteAccount', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('throws when user does not exist', async () => {
+    User.findById.mockResolvedValueOnce(null);
+
+    await expect(accountService.hardDeleteAccount('u1')).rejects.toMatchObject({
+      status: 404,
+      code: 'NOT_FOUND',
+    });
+  });
+
+  test('hard-deletes user and related data', async () => {
+    User.findById.mockResolvedValueOnce({ _id: 'u1', email: 'a@vnu.edu.vn' });
+
+    const result = await accountService.hardDeleteAccount('u1');
+
+    expect(StudentProfile.deleteMany).toHaveBeenCalledWith({ userId: 'u1' });
+    expect(RefreshToken.deleteMany).toHaveBeenCalledWith({ userId: 'u1' });
+    expect(Notification.deleteMany).toHaveBeenCalledWith({ userId: 'u1' });
+    expect(SecurityAudit.deleteMany).toHaveBeenCalledWith({ userId: 'u1' });
+    expect(AccountAuditEvent.deleteMany).toHaveBeenCalledWith({ userId: 'u1' });
+    expect(RoadmapProgress.deleteMany).toHaveBeenCalledWith({ userId: 'u1' });
+    expect(Roadmap.deleteMany).toHaveBeenCalledWith({ userId: 'u1' });
+    expect(ManualRoadmap.deleteMany).toHaveBeenCalledWith({ userId: 'u1' });
+    expect(User.deleteOne).toHaveBeenCalledWith({ _id: 'u1' });
+    expect(DeletedEmail.updateOne).toHaveBeenCalledWith(
+      { email: 'a@vnu.edu.vn' },
+      {
+        $set: {
+          deletedAt: expect.any(Date),
+        },
+      },
+      { upsert: true }
+    );
+    expect(result).toMatchObject({
+      code: 'ACCOUNT_DELETED',
+      message: 'Account deleted permanently.',
+    });
+  });
+});

--- a/backend/tests/unit/account/account.profile.get.test.js
+++ b/backend/tests/unit/account/account.profile.get.test.js
@@ -4,7 +4,14 @@ jest.mock('../../../src/modules/auth/user.model', () => ({
   },
 }));
 
+jest.mock('../../../src/modules/onboarding/onboarding.model', () => ({
+  StudentProfile: {
+    findOne: jest.fn(),
+  },
+}));
+
 const { User } = require('../../../src/modules/auth/user.model');
+const { StudentProfile } = require('../../../src/modules/onboarding/onboarding.model');
 const accountService = require('../../../src/modules/account/account.service');
 
 describe('account.service getProfile', () => {
@@ -19,6 +26,7 @@ describe('account.service getProfile', () => {
       privacySetting: 'identified',
       avatarUrl: 'https://cdn/avatar.png',
     });
+    StudentProfile.findOne.mockResolvedValueOnce(null);
 
     const result = await accountService.getProfile('u1');
     expect(result.identity).toEqual(

--- a/frontend/src/features/account/AccountSettingsPage.jsx
+++ b/frontend/src/features/account/AccountSettingsPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
+	AlertTriangle,
 	Camera,
 	CheckCircle2,
 	Eye,
@@ -19,6 +20,7 @@ import './account-settings-page.css';
 
 const AVATAR_MAX_DIMENSION = 512;
 const AVATAR_MAX_BYTES = 350 * 1024;
+const ACCOUNT_DELETE_CONFIRM_TEXT = 'DELETE';
 
 function estimateDataUrlBytes(dataUrl) {
 	const base64 = String(dataUrl || '').split(',')[1] || '';
@@ -99,6 +101,7 @@ export default function AccountSettingsPage() {
 	const [pageError, setPageError] = useState('');
 	const [showCurrentPassword, setShowCurrentPassword] = useState(false);
 	const [showNewPassword, setShowNewPassword] = useState(false);
+	const [accountDeleteConfirm, setAccountDeleteConfirm] = useState('');
 
 	const canSubmitPassword = useMemo(() => {
 		return Boolean(currentPassword.trim()) && isPasswordPolicyValid(newPassword);
@@ -125,6 +128,10 @@ export default function AccountSettingsPage() {
 		}
 		return { label: 'Strong', color: 'strong', score: 3 };
 	}, [newPassword]);
+
+	const canDeleteAccount = useMemo(() => {
+		return accountDeleteConfirm.trim().toUpperCase() === ACCOUNT_DELETE_CONFIRM_TEXT;
+	}, [accountDeleteConfirm]);
 
 	useEffect(() => {
 		async function loadProfile() {
@@ -271,6 +278,38 @@ export default function AccountSettingsPage() {
 			setNewPassword('');
 		} catch (err) {
 			const message = err?.message || 'Failed to change password';
+			addNotification(message, 'error');
+			setError(message);
+		} finally {
+			setLoading(false);
+		}
+	}
+
+	async function onHardDeleteAccount(event) {
+		event.preventDefault();
+		resetStatus();
+		setPageError('');
+
+		if (!canDeleteAccount) {
+			addNotification(`Type ${ACCOUNT_DELETE_CONFIRM_TEXT} to confirm account deletion.`, 'error');
+			return;
+		}
+
+		const shouldContinue =
+			typeof window === 'undefined'
+				? true
+				: window.confirm('This action permanently deletes your account and cannot be undone. Continue?');
+		if (!shouldContinue) {
+			return;
+		}
+
+		setLoading(true);
+		try {
+			const result = await accountApi.deleteAccount(accessToken);
+			addNotification(result?.message || 'Account deleted permanently.', 'success');
+			await logoutAndRedirect();
+		} catch (err) {
+			const message = err?.message || 'Failed to delete account';
 			addNotification(message, 'error');
 			setError(message);
 		} finally {
@@ -497,6 +536,40 @@ export default function AccountSettingsPage() {
 								Save Privacy Preference
 							</button>
 						</div>
+					</section>
+
+					<section className="danger-zone-card">
+						<div className="card-title-row danger-title-row">
+							<AlertTriangle size={18} />
+							<h2>Danger Zone</h2>
+						</div>
+						<p>
+							Hard delete will permanently remove this account and all related data in the
+							database.
+						</p>
+						<form onSubmit={onHardDeleteAccount}>
+							<div className="field">
+								<label htmlFor="accountDeleteConfirm">
+									Type {ACCOUNT_DELETE_CONFIRM_TEXT} to confirm
+								</label>
+								<input
+									id="accountDeleteConfirm"
+									value={accountDeleteConfirm}
+									onChange={(event) => setAccountDeleteConfirm(event.target.value)}
+									placeholder={ACCOUNT_DELETE_CONFIRM_TEXT}
+									disabled={loading}
+								/>
+							</div>
+							<div className="danger-actions">
+								<button
+									type="submit"
+									className="btn danger solid"
+									disabled={loading || !canDeleteAccount}
+								>
+									Delete Account Permanently
+								</button>
+							</div>
+						</form>
 					</section>
 				</main>
 

--- a/frontend/src/features/account/account-settings-page.css
+++ b/frontend/src/features/account/account-settings-page.css
@@ -192,6 +192,30 @@
   gap: 1.2rem;
 }
 
+.danger-zone-card {
+  margin-top: 1.2rem;
+  border: 1px solid #efc8c8;
+  background: #fff9f9;
+  border-radius: 16px;
+  box-shadow: 0 10px 28px rgba(91, 26, 26, 0.07);
+  padding: 1.5rem;
+}
+
+.danger-title-row {
+  color: #b03030;
+}
+
+.danger-zone-card > p {
+  margin: 0 0 1rem;
+  color: #7d3d3d;
+}
+
+.danger-actions {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
 .card-head-between {
   display: flex;
   justify-content: space-between;
@@ -374,6 +398,12 @@
   color: #b03030;
 }
 
+.btn.danger.solid {
+  border-color: #b03030;
+  background: linear-gradient(135deg, #c53939 0%, #9f1e1e 100%);
+  color: #ffffff;
+}
+
 .btn.full {
   width: 100%;
   margin-top: 1.1rem;
@@ -489,6 +519,20 @@ html[data-theme='dark'] .privacy-card {
   box-shadow: 0 12px 24px rgba(2, 9, 20, 0.45);
 }
 
+html[data-theme='dark'] .danger-zone-card {
+  border: 1px solid rgba(239, 131, 131, 0.4);
+  background: rgba(83, 30, 30, 0.28);
+  box-shadow: 0 12px 24px rgba(22, 6, 6, 0.45);
+}
+
+html[data-theme='dark'] .danger-title-row {
+  color: #ff9a9a;
+}
+
+html[data-theme='dark'] .danger-zone-card > p {
+  color: #f8bfbf;
+}
+
 html[data-theme='dark'] .avatar-image,
 html[data-theme='dark'] .avatar-fallback {
   border: 4px solid #1f3d63;
@@ -554,6 +598,12 @@ html[data-theme='dark'] .btn.danger {
   border-color: rgba(244, 114, 114, 0.45);
   background: rgba(127, 29, 29, 0.2);
   color: #fecaca;
+}
+
+html[data-theme='dark'] .btn.danger.solid {
+  border-color: rgba(248, 113, 113, 0.75);
+  background: linear-gradient(135deg, #dc2626 0%, #991b1b 100%);
+  color: #ffffff;
 }
 
 /* Dark theme - Account Settings */

--- a/frontend/src/services/account.api.js
+++ b/frontend/src/services/account.api.js
@@ -56,8 +56,15 @@ export function changePassword(token, payload) {
   });
 }
 
+export function deleteAccount(token) {
+  return requestAuthed('/account/hard-delete', token, {
+    method: 'DELETE',
+  });
+}
+
 export default {
   getProfile,
   updateProfile,
   changePassword,
+  deleteAccount,
 };


### PR DESCRIPTION
Add backend endpoint and service logic to permanently delete account-related data across collections, clear auth cookie, and expose API client support.

Introduce Account Settings danger zone UI with explicit confirmation for irreversible deletion, plus unit test coverage for hard-delete behavior and profile test mock update.