### PR TITLE
013 manual roadmap generator

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-	"feature_directory": "specs/014-community-roadmap-reviews"
+	"feature_directory": "specs/015-roadmap-tags"
 }

--- a/backend/src/modules/roadmap/manualRoadmap.model.js
+++ b/backend/src/modules/roadmap/manualRoadmap.model.js
@@ -148,6 +148,25 @@ const ManualRoadmapSchema = new mongoose.Schema(
             type: Date,
             default: null,
         },
+        tags: {
+            type: [
+                {
+                    label: {
+                        type: String,
+                        required: true,
+                        trim: true,
+                    },
+                    normalizedLabel: {
+                        type: String,
+                        required: true,
+                        trim: true,
+                        lowercase: true,
+                    },
+                    _id: false,
+                }
+            ],
+            default: [],
+        },
     },
     {
         collection: 'manual_roadmaps',

--- a/backend/src/modules/roadmap/manualRoadmap.service.js
+++ b/backend/src/modules/roadmap/manualRoadmap.service.js
@@ -65,13 +65,20 @@ async function syncToRoadmapCollection(roadmapId, userId, { title, nodes }) {
     );
 }
 
-async function listPublic({ q = '', page = 1, limit = 20 } = {}) {
+async function listPublic({ q = '', tags = [], page = 1, limit = 20 } = {}) {
     limit = Math.min(limit, 100);
-    const filter = {};
+    const filter = { isPublic: true };
 
     const normalizedQuery = String(q || '').trim();
     if (normalizedQuery) {
         filter.title = { $regex: escapeRegex(normalizedQuery), $options: 'i' };
+    }
+
+    if (Array.isArray(tags) && tags.length > 0) {
+        const normalizedTags = tags.map(t => String(t || '').trim().toLowerCase()).filter(Boolean);
+        if (normalizedTags.length > 0) {
+            filter['tags.normalizedLabel'] = { $in: normalizedTags };
+        }
     }
 
     const [items, total] = await Promise.all([
@@ -138,7 +145,7 @@ async function listByUser(userId, { page = 1, limit = 20 } = {}) {
     return { items, pagination: { page, limit, total } };
 }
 
-async function createDraft(userId, { title, description, yamlCode, nodes }) {
+async function createDraft(userId, { title, description, yamlCode, nodes, tags = [] }) {
     // Enrich nodes with defaults
     const enrichedNodes = enrichNodes(nodes);
 
@@ -162,6 +169,7 @@ async function createDraft(userId, { title, description, yamlCode, nodes }) {
         yamlCode,
         nodes: enrichedNodes,
         edges,
+        tags: Array.isArray(tags) ? tags : [],
         shared: true,
         isPublic: true,
         status: 'draft',
@@ -187,7 +195,7 @@ async function createDraft(userId, { title, description, yamlCode, nodes }) {
     return result;
 }
 
-async function updateDraft(roadmapId, userId, { title, description, yamlCode, nodes }) {
+async function updateDraft(roadmapId, userId, { title, description, yamlCode, nodes, tags = [] }) {
     const existing = await ManualRoadmap.findOne({ _id: roadmapId, userId });
     if (!existing) {
         throw new RoadmapError(404, ERROR_CODES.ROADMAP_NOT_FOUND, 'Manual roadmap not found.');
@@ -215,6 +223,7 @@ async function updateDraft(roadmapId, userId, { title, description, yamlCode, no
     existing.yamlCode = yamlCode;
     existing.nodes = enrichedNodes;
     existing.edges = edges;
+    existing.tags = Array.isArray(tags) ? tags : [];
     existing.shared = true;
     existing.isPublic = true;
     existing.sharedAt = existing.sharedAt || new Date();
@@ -238,6 +247,37 @@ async function updateDraft(roadmapId, userId, { title, description, yamlCode, no
     const out = existing.toObject();
     if (syncSkippedOnUpdate) out.syncSkipped = true;
     return out;
+}
+
+function serializeTag(tag) {
+    if (!tag || typeof tag !== 'object') {
+        return null;
+    }
+    return {
+        label: tag.label || '',
+        normalizedLabel: (tag.normalizedLabel || '').toLowerCase(),
+    };
+}
+
+async function getDistinctTags() {
+    const publicRoadmaps = await ManualRoadmap.find(
+        { isPublic: true },
+        { tags: 1 }
+    ).lean();
+
+    const tagMap = new Map();
+    for (const roadmap of publicRoadmaps) {
+        if (Array.isArray(roadmap.tags)) {
+            for (const tag of roadmap.tags) {
+                const normalized = (tag.normalizedLabel || '').toLowerCase();
+                if (normalized && !tagMap.has(normalized)) {
+                    tagMap.set(normalized, serializeTag(tag));
+                }
+            }
+        }
+    }
+
+    return Array.from(tagMap.values()).sort((a, b) => a.label.localeCompare(b.label));
 }
 
 async function share(roadmapId, userId) {
@@ -269,4 +309,6 @@ module.exports = {
     share,
     listPublic,
     getPublicPreviewById,
+    serializeTag,
+    getDistinctTags,
 };

--- a/backend/src/modules/roadmap/manualRoadmapValidation.service.js
+++ b/backend/src/modules/roadmap/manualRoadmapValidation.service.js
@@ -258,6 +258,48 @@ function validateManualRoadmapYaml(yamlCode) {
     };
 }
 
+function normalizeTag(tag) {
+    if (!tag || typeof tag !== 'object') {
+        return null;
+    }
+    const label = String(tag.label || '').trim();
+    if (!label) {
+        return null;
+    }
+    return {
+        label,
+        normalizedLabel: label.toLowerCase().trim(),
+    };
+}
+
+function validateAndNormalizeTags(tags) {
+    if (!tags) {
+        return [];
+    }
+    if (!Array.isArray(tags)) {
+        throw new RoadmapError(422, ERROR_CODES.VALIDATION_ERROR, 'Tags must be an array.');
+    }
+
+    const normalized = [];
+    const seen = new Set();
+
+    for (const tag of tags) {
+        const normalized_tag = normalizeTag(tag);
+        if (!normalized_tag) {
+            continue;
+        }
+        if (seen.has(normalized_tag.normalizedLabel)) {
+            continue;
+        }
+        seen.add(normalized_tag.normalizedLabel);
+        normalized.push(normalized_tag);
+    }
+
+    return normalized;
+}
+
 module.exports = {
     validateManualRoadmapYaml,
+    normalizeTag,
+    validateAndNormalizeTags,
 };

--- a/backend/src/modules/roadmap/roadmap.controller.js
+++ b/backend/src/modules/roadmap/roadmap.controller.js
@@ -56,15 +56,23 @@ async function getRoadmapById(req, res) {
 
 async function listPublicManualRoadmaps(req, res) {
 	try {
-		const { q, page, limit } = req.query;
+		const { q, tags, page, limit } = req.query;
 		const normalizedQuery = String(q || '').trim();
 
 		if (normalizedQuery.length > 0 && normalizedQuery.length < 2) {
 			throw new RoadmapError(400, ERROR_CODES.INVALID_PAYLOAD, 'Search query must be at least 2 characters.');
 		}
 
+		// Parse tags parameter (can be string or array)
+		let selectedTags = [];
+		if (tags) {
+			selectedTags = Array.isArray(tags) ? tags : [tags];
+			selectedTags = selectedTags.map(tag => String(tag || '').trim().toLowerCase()).filter(Boolean);
+		}
+
 		const result = await manualRoadmapService.listPublic({
 			q: normalizedQuery,
+			tags: selectedTags,
 			page: parsePositiveIntQuery(page, 'page'),
 			limit: parsePositiveIntQuery(limit, 'limit'),
 		});
@@ -98,15 +106,18 @@ async function getManualRoadmapById(req, res) {
 
 async function createManualRoadmap(req, res) {
 	try {
-		const { yamlCode } = req.body ?? {};
+		const { yamlCode, tags } = req.body ?? {};
 		const parsed = manualRoadmapValidation.validateManualRoadmapYaml(String(yamlCode || ''));
 		const { title, description, nodes } = parsed;
+
+		const normalizedTags = manualRoadmapValidation.validateAndNormalizeTags(tags);
 
 		const roadmap = await manualRoadmapService.createDraft(req.user.userId, {
 			title,
 			description,
 			yamlCode: String(yamlCode || '').trim(),
 			nodes,
+			tags: normalizedTags,
 		});
 
 		return res.status(201).json(roadmap);
@@ -117,15 +128,18 @@ async function createManualRoadmap(req, res) {
 
 async function updateManualRoadmap(req, res) {
 	try {
-		const { yamlCode } = req.body ?? {};
+		const { yamlCode, tags } = req.body ?? {};
 		const parsed = manualRoadmapValidation.validateManualRoadmapYaml(String(yamlCode || ''));
 		const { title, description, nodes } = parsed;
+
+		const normalizedTags = manualRoadmapValidation.validateAndNormalizeTags(tags);
 
 		const roadmap = await manualRoadmapService.updateDraft(req.params.roadmapId, req.user.userId, {
 			title,
 			description,
 			yamlCode: String(yamlCode || '').trim(),
 			nodes,
+			tags: normalizedTags,
 		});
 
 		return res.json(roadmap);
@@ -295,6 +309,15 @@ async function updateNodeStateHandler(req, res) {
 	}
 }
 
+async function getManualRoadmapTags(req, res) {
+	try {
+		const tags = await manualRoadmapService.getDistinctTags();
+		return res.json(tags);
+	} catch (err) {
+		return mapError(err, res);
+	}
+}
+
 module.exports = {
 	getPublicSharedRoadmap,
 	getPrimaryRoadmap,
@@ -313,4 +336,5 @@ module.exports = {
 	previewRoadmapHandler,
 	getProgressHandler,
 	updateNodeStateHandler,
+	getManualRoadmapTags,
 };

--- a/backend/src/modules/roadmap/roadmap.routes.js
+++ b/backend/src/modules/roadmap/roadmap.routes.js
@@ -15,6 +15,7 @@ const roadmapRouter = express.Router();
 roadmapRouter.get('/public', controller.getPublicSharedRoadmap);
 roadmapRouter.get('/manual-roadmaps/public', controller.listPublicManualRoadmaps);
 roadmapRouter.get('/manual-roadmaps/public/:roadmapId', controller.getPublicManualRoadmapPreviewById);
+roadmapRouter.get('/manual-roadmaps/tags', controller.getManualRoadmapTags);
 
 // SSE endpoint supports EventSource by authenticating with JWT passed via sseToken query.
 roadmapRouter.get('/sse', (req, res) => {

--- a/backend/tests/unit/roadmap/manualRoadmap.service.test.js
+++ b/backend/tests/unit/roadmap/manualRoadmap.service.test.js
@@ -1,0 +1,312 @@
+'use strict';
+
+/**
+ * Unit tests for manualRoadmap.service.js — Tag persistence
+ * Tests: createDraft with tags, updateDraft with tags, getDistinctTags
+ */
+
+jest.mock('../../../src/modules/roadmap/manualRoadmap.model');
+jest.mock('../../../src/modules/roadmap/graph.generator');
+jest.mock('../../../src/modules/roadmap/roadmap.model');
+jest.mock('../../../src/modules/onboarding/onboarding.model', () => ({
+    StudentProfile: {
+        findOne: jest.fn(),
+    },
+}));
+
+const { ManualRoadmap } = require('../../../src/modules/roadmap/manualRoadmap.model');
+const manualRoadmapService = require('../../../src/modules/roadmap/manualRoadmap.service');
+const { enrichNodes, generateEdgesFromHierarchy, validateHierarchy } = require('../../../src/modules/roadmap/graph.generator');
+const { StudentProfile } = require('../../../src/modules/onboarding/onboarding.model');
+const { Roadmap } = require('../../../src/modules/roadmap/roadmap.model');
+
+const userId = 'user001';
+const roadmapId = 'roadmap001';
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    enrichNodes.mockImplementation(nodes => nodes || []);
+    generateEdgesFromHierarchy.mockReturnValue([]);
+    validateHierarchy.mockReturnValue({ isValid: true, errors: [] });
+    StudentProfile.findOne.mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+            _id: 'profile001',
+            userId,
+        }),
+    });
+    Roadmap.findOneAndUpdate = jest.fn().mockResolvedValue({});
+});
+
+describe('manualRoadmap.service — createDraft with tags', () => {
+    test('creates a roadmap with tags', async () => {
+        const mockRoadmap = {
+            _id: roadmapId,
+            userId,
+            title: 'Test Roadmap',
+            description: 'Test',
+            yamlCode: 'title: Test',
+            tags: [
+                { label: 'Frontend', normalizedLabel: 'frontend' },
+                { label: 'React', normalizedLabel: 'react' },
+            ],
+            toObject: () => ({
+                _id: roadmapId,
+                userId,
+                title: 'Test Roadmap',
+                tags: [
+                    { label: 'Frontend', normalizedLabel: 'frontend' },
+                    { label: 'React', normalizedLabel: 'react' },
+                ],
+            }),
+        };
+
+        ManualRoadmap.create = jest.fn().mockResolvedValue(mockRoadmap);
+
+        const result = await manualRoadmapService.createDraft(userId, {
+            title: 'Test Roadmap',
+            description: 'Test',
+            yamlCode: 'title: Test',
+            nodes: [],
+            tags: [
+                { label: 'Frontend', normalizedLabel: 'frontend' },
+                { label: 'React', normalizedLabel: 'react' },
+            ],
+        });
+
+        expect(ManualRoadmap.create).toHaveBeenCalled();
+        const createCall = ManualRoadmap.create.mock.calls[0][0];
+        expect(createCall.tags).toEqual([
+            { label: 'Frontend', normalizedLabel: 'frontend' },
+            { label: 'React', normalizedLabel: 'react' },
+        ]);
+        expect(result.tags).toEqual([
+            { label: 'Frontend', normalizedLabel: 'frontend' },
+            { label: 'React', normalizedLabel: 'react' },
+        ]);
+    });
+
+    test('creates a roadmap with empty tags array when none provided', async () => {
+        const mockRoadmap = {
+            _id: roadmapId,
+            userId,
+            title: 'Test Roadmap',
+            tags: [],
+            toObject: () => ({
+                _id: roadmapId,
+                userId,
+                title: 'Test Roadmap',
+                tags: [],
+            }),
+        };
+
+        ManualRoadmap.create = jest.fn().mockResolvedValue(mockRoadmap);
+
+        await manualRoadmapService.createDraft(userId, {
+            title: 'Test Roadmap',
+            yamlCode: 'title: Test',
+            nodes: [],
+        });
+
+        const createCall = ManualRoadmap.create.mock.calls[0][0];
+        expect(createCall.tags).toEqual([]);
+    });
+});
+
+describe('manualRoadmap.service — updateDraft with tags', () => {
+    test('updates a roadmap with new tags', async () => {
+        const mockRoadmap = {
+            _id: roadmapId,
+            userId,
+            title: 'Updated Roadmap',
+            status: 'draft',
+            tags: [],
+            save: jest.fn().mockResolvedValue(true),
+            toObject: () => ({
+                _id: roadmapId,
+                title: 'Updated Roadmap',
+                tags: [
+                    { label: 'Backend', normalizedLabel: 'backend' },
+                    { label: 'Node.js', normalizedLabel: 'node.js' },
+                ],
+            }),
+        };
+
+        ManualRoadmap.findOne = jest.fn().mockResolvedValue(mockRoadmap);
+
+        const result = await manualRoadmapService.updateDraft(roadmapId, userId, {
+            title: 'Updated Roadmap',
+            yamlCode: 'title: Updated',
+            nodes: [],
+            tags: [
+                { label: 'Backend', normalizedLabel: 'backend' },
+                { label: 'Node.js', normalizedLabel: 'node.js' },
+            ],
+        });
+
+        expect(mockRoadmap.tags).toEqual([
+            { label: 'Backend', normalizedLabel: 'backend' },
+            { label: 'Node.js', normalizedLabel: 'node.js' },
+        ]);
+        expect(result.tags).toEqual([
+            { label: 'Backend', normalizedLabel: 'backend' },
+            { label: 'Node.js', normalizedLabel: 'node.js' },
+        ]);
+    });
+
+    test('preserves tags when updating a roadmap without providing tags', async () => {
+        const originalTags = [{ label: 'Existing', normalizedLabel: 'existing' }];
+        const mockRoadmap = {
+            _id: roadmapId,
+            userId,
+            title: 'Updated Roadmap',
+            status: 'draft',
+            tags: originalTags,
+            save: jest.fn().mockResolvedValue(true),
+            toObject: () => ({
+                _id: roadmapId,
+                title: 'Updated Roadmap',
+                tags: [],
+            }),
+        };
+
+        ManualRoadmap.findOne = jest.fn().mockResolvedValue(mockRoadmap);
+
+        await manualRoadmapService.updateDraft(roadmapId, userId, {
+            title: 'Updated Roadmap',
+            yamlCode: 'title: Updated',
+            nodes: [],
+        });
+
+        // When no tags provided, it should set to empty array (not preserve)
+        expect(mockRoadmap.tags).toEqual([]);
+    });
+
+    test('throws error when roadmap not found', async () => {
+        ManualRoadmap.findOne = jest.fn().mockResolvedValue(null);
+
+        await expect(
+            manualRoadmapService.updateDraft(roadmapId, userId, {
+                title: 'Updated',
+                yamlCode: 'title: Updated',
+                nodes: [],
+                tags: [],
+            })
+        ).rejects.toThrow('Manual roadmap not found.');
+    });
+
+    test('throws error when roadmap is not draft status', async () => {
+        const mockRoadmap = {
+            _id: roadmapId,
+            userId,
+            status: 'published',
+        };
+
+        ManualRoadmap.findOne = jest.fn().mockResolvedValue(mockRoadmap);
+
+        await expect(
+            manualRoadmapService.updateDraft(roadmapId, userId, {
+                title: 'Updated',
+                yamlCode: 'title: Updated',
+                nodes: [],
+                tags: [],
+            })
+        ).rejects.toThrow('Only draft roadmaps can be updated.');
+    });
+});
+
+describe('manualRoadmap.service — getDistinctTags', () => {
+    test('returns distinct tags from all public roadmaps', async () => {
+        const mockRoadmaps = [
+            {
+                _id: 'roadmap1',
+                tags: [
+                    { label: 'Frontend', normalizedLabel: 'frontend' },
+                    { label: 'React', normalizedLabel: 'react' },
+                ],
+            },
+            {
+                _id: 'roadmap2',
+                tags: [
+                    { label: 'React', normalizedLabel: 'react' },
+                    { label: 'Node.js', normalizedLabel: 'node.js' },
+                ],
+            },
+        ];
+
+        ManualRoadmap.find = jest.fn().mockReturnValue({
+            lean: () => Promise.resolve(mockRoadmaps),
+        });
+
+        const result = await manualRoadmapService.getDistinctTags();
+
+        expect(ManualRoadmap.find).toHaveBeenCalledWith({ isPublic: true }, { tags: 1 });
+        expect(result).toHaveLength(3);
+        expect(result.map(t => t.normalizedLabel)).toContain('frontend');
+        expect(result.map(t => t.normalizedLabel)).toContain('react');
+        expect(result.map(t => t.normalizedLabel)).toContain('node.js');
+    });
+
+    test('returns empty array when no public roadmaps exist', async () => {
+        ManualRoadmap.find = jest.fn().mockReturnValue({
+            lean: () => Promise.resolve([]),
+        });
+
+        const result = await manualRoadmapService.getDistinctTags();
+
+        expect(result).toEqual([]);
+    });
+
+    test('returns empty array when public roadmaps have no tags', async () => {
+        const mockRoadmaps = [
+            { _id: 'roadmap1', tags: [] },
+            { _id: 'roadmap2', tags: [] },
+        ];
+
+        ManualRoadmap.find = jest.fn().mockReturnValue({
+            lean: () => Promise.resolve(mockRoadmaps),
+        });
+
+        const result = await manualRoadmapService.getDistinctTags();
+
+        expect(result).toEqual([]);
+    });
+
+    test('handles roadmaps with missing tags field', async () => {
+        const mockRoadmaps = [
+            { _id: 'roadmap1', tags: [{ label: 'Frontend', normalizedLabel: 'frontend' }] },
+            { _id: 'roadmap2' }, // no tags field
+        ];
+
+        ManualRoadmap.find = jest.fn().mockReturnValue({
+            lean: () => Promise.resolve(mockRoadmaps),
+        });
+
+        const result = await manualRoadmapService.getDistinctTags();
+
+        expect(result).toHaveLength(1);
+        expect(result[0].label).toBe('Frontend');
+    });
+
+    test('returns tags sorted by label', async () => {
+        const mockRoadmaps = [
+            {
+                _id: 'roadmap1',
+                tags: [
+                    { label: 'Zebra', normalizedLabel: 'zebra' },
+                    { label: 'Apple', normalizedLabel: 'apple' },
+                    { label: 'Mango', normalizedLabel: 'mango' },
+                ],
+            },
+        ];
+
+        ManualRoadmap.find = jest.fn().mockReturnValue({
+            lean: () => Promise.resolve(mockRoadmaps),
+        });
+
+        const result = await manualRoadmapService.getDistinctTags();
+
+        expect(result[0].label).toBe('Apple');
+        expect(result[1].label).toBe('Mango');
+        expect(result[2].label).toBe('Zebra');
+    });
+});

--- a/backend/tests/unit/roadmap/manualRoadmapValidation.service.test.js
+++ b/backend/tests/unit/roadmap/manualRoadmapValidation.service.test.js
@@ -1,0 +1,139 @@
+'use strict';
+
+/**
+ * Unit tests for manualRoadmapValidation.service.js — Tag validation functions
+ * Tests: normalizeTag, validateAndNormalizeTags (deduplication, empty handling)
+ */
+
+const { normalizeTag, validateAndNormalizeTags } = require('../../../src/modules/roadmap/manualRoadmapValidation.service');
+
+describe('manualRoadmapValidation.service — normalizeTag', () => {
+    test('normalizes a valid tag with label', () => {
+        const tag = { label: 'JavaScript' };
+        const result = normalizeTag(tag);
+
+        expect(result).toEqual({
+            label: 'JavaScript',
+            normalizedLabel: 'javascript',
+        });
+    });
+
+    test('trims whitespace from label', () => {
+        const tag = { label: '  Web Development  ' };
+        const result = normalizeTag(tag);
+
+        expect(result).toEqual({
+            label: 'Web Development',
+            normalizedLabel: 'web development',
+        });
+    });
+
+    test('returns null when tag is null', () => {
+        const result = normalizeTag(null);
+        expect(result).toBeNull();
+    });
+
+    test('returns null when label is empty string', () => {
+        const tag = { label: '' };
+        const result = normalizeTag(tag);
+        expect(result).toBeNull();
+    });
+
+    test('returns null when label is whitespace only', () => {
+        const tag = { label: '   ' };
+        const result = normalizeTag(tag);
+        expect(result).toBeNull();
+    });
+});
+
+describe('manualRoadmapValidation.service — validateAndNormalizeTags', () => {
+    test('returns empty array when tags is null', () => {
+        const result = validateAndNormalizeTags(null);
+        expect(result).toEqual([]);
+    });
+
+    test('returns empty array when tags is undefined', () => {
+        const result = validateAndNormalizeTags(undefined);
+        expect(result).toEqual([]);
+    });
+
+    test('returns empty array when tags is empty array', () => {
+        const result = validateAndNormalizeTags([]);
+        expect(result).toEqual([]);
+    });
+
+    test('normalizes a single tag', () => {
+        const tags = [{ label: 'React' }];
+        const result = validateAndNormalizeTags(tags);
+
+        expect(result).toEqual([
+            { label: 'React', normalizedLabel: 'react' },
+        ]);
+    });
+
+    test('normalizes multiple unique tags', () => {
+        const tags = [
+            { label: 'Frontend' },
+            { label: 'JavaScript' },
+            { label: 'React' },
+        ];
+        const result = validateAndNormalizeTags(tags);
+
+        expect(result).toEqual([
+            { label: 'Frontend', normalizedLabel: 'frontend' },
+            { label: 'JavaScript', normalizedLabel: 'javascript' },
+            { label: 'React', normalizedLabel: 'react' },
+        ]);
+    });
+
+    test('removes duplicate tags based on normalized label', () => {
+        const tags = [
+            { label: 'React' },
+            { label: 'react' },
+            { label: 'REACT' },
+        ];
+        const result = validateAndNormalizeTags(tags);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].label).toBe('React');
+        expect(result[0].normalizedLabel).toBe('react');
+    });
+
+    test('skips tags with empty labels', () => {
+        const tags = [
+            { label: 'Frontend' },
+            { label: '' },
+            { label: 'Backend' },
+        ];
+        const result = validateAndNormalizeTags(tags);
+
+        expect(result).toHaveLength(2);
+        expect(result).toEqual([
+            { label: 'Frontend', normalizedLabel: 'frontend' },
+            { label: 'Backend', normalizedLabel: 'backend' },
+        ]);
+    });
+
+    test('preserves order of first occurrence when deduplicating', () => {
+        const tags = [
+            { label: 'First' },
+            { label: 'Second' },
+            { label: 'first' }, // duplicate
+            { label: 'Third' },
+        ];
+        const result = validateAndNormalizeTags(tags);
+
+        expect(result).toHaveLength(3);
+        expect(result[0].label).toBe('First');
+        expect(result[1].label).toBe('Second');
+        expect(result[2].label).toBe('Third');
+    });
+
+    test('throws error when tags is not an array', () => {
+        expect(() => validateAndNormalizeTags('not-an-array')).toThrow('Tags must be an array.');
+    });
+
+    test('throws error when tags is an object', () => {
+        expect(() => validateAndNormalizeTags({ label: 'Tag' })).toThrow('Tags must be an array.');
+    });
+});

--- a/frontend/src/features/general/NavBar.jsx
+++ b/frontend/src/features/general/NavBar.jsx
@@ -42,14 +42,6 @@ export function getRoadmapSearchTarget(pathname) {
   return !blockedPaths.includes(pathname);
 }
 
-function dispatchRoadmapSearchQuery(query) {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  window.dispatchEvent(new CustomEvent('roadmap-search-query', { detail: { query } }));
-}
-
 function dispatchOpenRoadmapSearchOverlay() {
   if (typeof window === 'undefined') {
     return;
@@ -102,7 +94,6 @@ export default function NavBar() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState('');
   const [avatarFallback, setAvatarFallback] = useState('U');
-  const [searchText, setSearchText] = useState('');
   const [theme, setTheme] = useState(resolveInitialTheme);
   const [notificationOpen, setNotificationOpen] = useState(false);
   const avatarRef = useRef(null);
@@ -265,19 +256,6 @@ export default function NavBar() {
     };
   }, [accessToken, isAuthenticated]);
 
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    const params = new URLSearchParams(window.location.search);
-    const initialQuery = String(params.get('q') || '').trim();
-    if (initialQuery) {
-      setSearchText(initialQuery);
-      dispatchRoadmapSearchQuery(initialQuery);
-    }
-  }, []);
-
   const navigationItems = isAuthenticated
     ? [
       {
@@ -337,21 +315,15 @@ export default function NavBar() {
         </div>
       </div>
       <div className="navbar__right">
-        <div className="navbar__search" onClick={goRoadmapSearch}>
-          <Search className="navbar__search-icon" size={16} />
-          <input
-            className="navbar__input"
-            type="text"
-            placeholder="Tìm kiếm roadmap..."
-            value={searchText}
-            onFocus={goRoadmapSearch}
-            onChange={(event) => {
-              const nextValue = event.target.value;
-              setSearchText(nextValue);
-              dispatchRoadmapSearchQuery(nextValue);
-            }}
-          />
-        </div>
+        <button
+          type="button"
+          className="navbar__icon-btn navbar__search-trigger"
+          aria-label="Tìm kiếm roadmap"
+          title="Tìm kiếm roadmap"
+          onClick={goRoadmapSearch}
+        >
+          <Search size={18} aria-hidden="true" />
+        </button>
         <div className="navbar__actions">
           <div className="navbar__notification" ref={notificationRef}>
             <button

--- a/frontend/src/features/manual-roadmap/ManualRoadmapPage.jsx
+++ b/frontend/src/features/manual-roadmap/ManualRoadmapPage.jsx
@@ -9,6 +9,7 @@ import { computeLayoutSafe } from '../../shared/elkLayoutEngine';
 import ManualRoadmapDividerHandle from './ManualRoadmapDividerHandle';
 import YamlGuideOverlay from './YamlGuideOverlay';
 import { useNotification } from '../notification/NotificationContainer';
+import TagInput from './TagInput';
 import { CircleHelp, History, Save } from 'lucide-react';
 import '../skill-tree/skill-tree.css';
 import './manual-roadmap.css';
@@ -148,6 +149,9 @@ export default function ManualRoadmapPage() {
   const [description, setDescription] = useState('');
   const [preview, setPreview] = useState({ title: '', description: '', nodes: [], edges: [] });
   const [validationError, setValidationError] = useState('');
+  const [tags, setTags] = useState([]);
+  const [availableTags, setAvailableTags] = useState([]);
+  const [isLoadingTags, setIsLoadingTags] = useState(false);
   const [apiError, setApiError] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
   const [isSaving, setIsSaving] = useState(false);
@@ -247,6 +251,33 @@ export default function ManualRoadmapPage() {
     } catch {
       // Ignore malformed prefill payload and keep default editor content.
     }
+  }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+    setIsLoadingTags(true);
+
+    (async () => {
+      try {
+        const tags = await manualRoadmapApi.getManualRoadmapTags();
+        if (isMounted) {
+          setAvailableTags(Array.isArray(tags) ? tags : []);
+        }
+      } catch (err) {
+        console.error('Failed to load tag catalog:', err);
+        if (isMounted) {
+          setAvailableTags([]);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoadingTags(false);
+        }
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   useEffect(() => {
@@ -453,6 +484,7 @@ export default function ManualRoadmapPage() {
         setSelectedSampleKey('custom');
         setTitle(roadmap.title || '');
         setDescription(roadmap.description || '');
+        setTags(Array.isArray(roadmap.tags) ? roadmap.tags : []);
       } catch (err) {
         if (!isMounted) return;
         setApiError(err.message || 'Không thể tải roadmap thủ công.');
@@ -600,8 +632,8 @@ export default function ManualRoadmapPage() {
     setIsSaving(true);
     try {
       const result = await (roadmapId
-        ? manualRoadmapApi.updateManualRoadmap(accessToken, roadmapId, { yamlCode: persistableYamlCode })
-        : manualRoadmapApi.createManualRoadmap(accessToken, { yamlCode: persistableYamlCode }));
+        ? manualRoadmapApi.updateManualRoadmap(accessToken, roadmapId, { yamlCode: persistableYamlCode, tags })
+        : manualRoadmapApi.createManualRoadmap(accessToken, { yamlCode: persistableYamlCode, tags }));
 
       setSuccessMessage(`Đã ${roadmapId ? 'cập nhật' : 'tạo'} roadmap thành công.`);
 
@@ -796,6 +828,21 @@ export default function ManualRoadmapPage() {
                 />
               </div>
               {validationError && <div className="manual-roadmap-alert manual-roadmap-alert--error">{validationError}</div>}
+            </section>
+
+            <section className="resources-tab__section manual-roadmap-section">
+              <h4 className="resources-tab__heading">Gắn thẻ roadmap</h4>
+              <div className="manual-roadmap-form">
+                <label className="manual-roadmap-field__label">Thêm hoặc chọn thẻ</label>
+                <TagInput
+                  tags={tags}
+                  availableTags={availableTags}
+                  onTagsChange={setTags}
+                  isLoading={isLoadingTags}
+                  disabled={isSaving}
+                />
+                <p className="manual-roadmap-section__note">Sử dụng thẻ để giúp người dùng tìm kiếm và lọc roadmap của bạn.</p>
+              </div>
             </section>
 
             <section className="resources-tab__section manual-roadmap-section">

--- a/frontend/src/features/manual-roadmap/ManualRoadmapPage.test.jsx
+++ b/frontend/src/features/manual-roadmap/ManualRoadmapPage.test.jsx
@@ -1,0 +1,193 @@
+describe('Manual Roadmap Tag Editor behavior', () => {
+    test('normalizes tag labels for comparison', async () => {
+        const normalizeTagLabel = (label) => String(label || '').trim().toLowerCase();
+
+        expect(normalizeTagLabel('React')).toBe('react');
+        expect(normalizeTagLabel('  JavaScript  ')).toBe('javascript');
+        expect(normalizeTagLabel('WEB DEVELOPMENT')).toBe('web development');
+    });
+
+    test('detects duplicate tags based on normalized label', async () => {
+        const isDuplicateTag = (newTag, existingTags) => {
+            const normalized = String(newTag.label || '').trim().toLowerCase();
+            return existingTags.some(
+                tag => String(tag.label || '').trim().toLowerCase() === normalized
+            );
+        };
+
+        const existingTags = [
+            { label: 'React', normalizedLabel: 'react' },
+            { label: 'Frontend', normalizedLabel: 'frontend' },
+        ];
+
+        expect(isDuplicateTag({ label: 'React' }, existingTags)).toBe(true);
+        expect(isDuplicateTag({ label: 'react' }, existingTags)).toBe(true);
+        expect(isDuplicateTag({ label: 'REACT' }, existingTags)).toBe(true);
+        expect(isDuplicateTag({ label: 'Backend' }, existingTags)).toBe(false);
+    });
+
+    test('creates a new tag from user input', async () => {
+        const createTag = (label) => {
+            if (!label) return null;
+            const trimmed = String(label).trim();
+            if (!trimmed) return null;
+            return {
+                label: trimmed,
+                normalizedLabel: trimmed.toLowerCase(),
+            };
+        };
+
+        expect(createTag('JavaScript')).toEqual({
+            label: 'JavaScript',
+            normalizedLabel: 'javascript',
+        });
+
+        expect(createTag('  React  ')).toEqual({
+            label: 'React',
+            normalizedLabel: 'react',
+        });
+
+        expect(createTag('')).toBeNull();
+        expect(createTag('   ')).toBeNull();
+        expect(createTag(null)).toBeNull();
+    });
+
+    test('adds a tag to the editor state', async () => {
+        const addTag = (tags, newTag) => {
+            if (!newTag || !newTag.label) return tags;
+            const isDuplicate = tags.some(
+                tag => tag.normalizedLabel === newTag.normalizedLabel
+            );
+            if (isDuplicate) return tags;
+            return [...tags, newTag];
+        };
+
+        const initialTags = [
+            { label: 'Frontend', normalizedLabel: 'frontend' },
+        ];
+
+        const newTag = { label: 'React', normalizedLabel: 'react' };
+        const result = addTag(initialTags, newTag);
+
+        expect(result).toHaveLength(2);
+        expect(result[1]).toEqual(newTag);
+    });
+
+    test('prevents adding duplicate tags', async () => {
+        const addTag = (tags, newTag) => {
+            if (!newTag || !newTag.label) return tags;
+            const isDuplicate = tags.some(
+                tag => tag.normalizedLabel === newTag.normalizedLabel
+            );
+            if (isDuplicate) return tags;
+            return [...tags, newTag];
+        };
+
+        const initialTags = [
+            { label: 'Frontend', normalizedLabel: 'frontend' },
+        ];
+
+        const duplicateTag = { label: 'frontend', normalizedLabel: 'frontend' };
+        const result = addTag(initialTags, duplicateTag);
+
+        expect(result).toEqual(initialTags);
+        expect(result).toHaveLength(1);
+    });
+
+    test('removes a tag from the editor state', async () => {
+        const removeTag = (tags, normalizedLabel) => {
+            return tags.filter(tag => tag.normalizedLabel !== normalizedLabel);
+        };
+
+        const tags = [
+            { label: 'Frontend', normalizedLabel: 'frontend' },
+            { label: 'React', normalizedLabel: 'react' },
+            { label: 'JavaScript', normalizedLabel: 'javascript' },
+        ];
+
+        const result = removeTag(tags, 'react');
+
+        expect(result).toHaveLength(2);
+        expect(result.map(t => t.normalizedLabel)).not.toContain('react');
+    });
+
+    test('replaces a tag in the editor state', async () => {
+        const replaceTag = (tags, oldNormalizedLabel, newTag) => {
+            const isDuplicate = tags.some(
+                tag => tag.normalizedLabel === newTag.normalizedLabel &&
+                    tag.normalizedLabel !== oldNormalizedLabel
+            );
+            if (isDuplicate) return tags;
+
+            return tags.map(tag =>
+                tag.normalizedLabel === oldNormalizedLabel ? newTag : tag
+            );
+        };
+
+        const tags = [
+            { label: 'Frontend', normalizedLabel: 'frontend' },
+            { label: 'React', normalizedLabel: 'react' },
+        ];
+
+        const newTag = { label: 'Vue', normalizedLabel: 'vue' };
+        const result = replaceTag(tags, 'react', newTag);
+
+        expect(result).toHaveLength(2);
+        expect(result.map(t => t.normalizedLabel)).toContain('vue');
+        expect(result.map(t => t.normalizedLabel)).not.toContain('react');
+    });
+
+    test('prevents replacing with duplicate tag', async () => {
+        const replaceTag = (tags, oldNormalizedLabel, newTag) => {
+            const isDuplicate = tags.some(
+                tag => tag.normalizedLabel === newTag.normalizedLabel &&
+                    tag.normalizedLabel !== oldNormalizedLabel
+            );
+            if (isDuplicate) return tags;
+
+            return tags.map(tag =>
+                tag.normalizedLabel === oldNormalizedLabel ? newTag : tag
+            );
+        };
+
+        const tags = [
+            { label: 'Frontend', normalizedLabel: 'frontend' },
+            { label: 'React', normalizedLabel: 'react' },
+        ];
+
+        const duplicateTag = { label: 'Frontend', normalizedLabel: 'frontend' };
+        const result = replaceTag(tags, 'react', duplicateTag);
+
+        expect(result).toEqual(tags);
+    });
+
+    test('handles roadmap with no tags on load', async () => {
+        const initializeRoadmapTags = (roadmapData) => {
+            return Array.isArray(roadmapData?.tags) ? roadmapData.tags : [];
+        };
+
+        expect(initializeRoadmapTags({})).toEqual([]);
+        expect(initializeRoadmapTags({ tags: undefined })).toEqual([]);
+        expect(initializeRoadmapTags({ tags: null })).toEqual([]);
+    });
+
+    test('preserves tags from existing roadmap on load', async () => {
+        const initializeRoadmapTags = (roadmapData) => {
+            return Array.isArray(roadmapData?.tags) ? roadmapData.tags : [];
+        };
+
+        const roadmapData = {
+            title: 'My Roadmap',
+            tags: [
+                { label: 'Frontend', normalizedLabel: 'frontend' },
+                { label: 'React', normalizedLabel: 'react' },
+            ],
+        };
+
+        const result = initializeRoadmapTags(roadmapData);
+
+        expect(result).toHaveLength(2);
+        expect(result[0].label).toBe('Frontend');
+        expect(result[1].label).toBe('React');
+    });
+});

--- a/frontend/src/features/manual-roadmap/TagInput.jsx
+++ b/frontend/src/features/manual-roadmap/TagInput.jsx
@@ -1,0 +1,206 @@
+import React, { useRef, useState, useCallback } from 'react';
+import { X, ChevronDown } from 'lucide-react';
+import './tag-input.css';
+
+/**
+ * TagInput Component
+ * Displays current tags as removable chips and allows adding new tags
+ * Features:
+ * - Tag chip display with remove button
+ * - Autocomplete suggestions from available tags
+ * - Duplicate prevention
+ * - Free-form tag creation (if not matching suggestions)
+ * - Click outside to close dropdown
+ */
+export default function TagInput({
+    tags = [],
+    availableTags = [],
+    onTagsChange = () => { },
+    isLoading = false,
+    disabled = false,
+}) {
+    const [inputValue, setInputValue] = useState('');
+    const [isOpen, setIsOpen] = useState(false);
+    const inputRef = useRef(null);
+    const containerRef = useRef(null);
+
+    // Get normalized labels of existing tags
+    const existingNormalizedLabels = new Set(
+        tags.map(tag => String(tag.label || '').trim().toLowerCase())
+    );
+
+    // Filter available tags to show only non-duplicates, ordered by relevance to input
+    const filteredSuggestions = useCallback(() => {
+        const normalizedInput = String(inputValue || '').trim().toLowerCase();
+
+        if (!normalizedInput) {
+            return availableTags.filter(tag =>
+                !existingNormalizedLabels.has(String(tag.normalizedLabel || '').toLowerCase())
+            ).slice(0, 8);
+        }
+
+        return availableTags
+            .filter(tag => {
+                const normalized = String(tag.normalizedLabel || '').toLowerCase();
+                return !existingNormalizedLabels.has(normalized) &&
+                    normalized.includes(normalizedInput);
+            })
+            .slice(0, 8);
+    }, [inputValue, availableTags, existingNormalizedLabels]);
+
+    // Handle add tag from suggestion or input
+    const addTag = useCallback((label) => {
+        const trimmed = String(label || '').trim();
+        if (!trimmed) return;
+
+        const normalized = trimmed.toLowerCase();
+        if (existingNormalizedLabels.has(normalized)) {
+            return; // Duplicate prevention
+        }
+
+        const newTag = {
+            label: trimmed,
+            normalizedLabel: normalized,
+        };
+
+        onTagsChange([...tags, newTag]);
+        setInputValue('');
+        setIsOpen(false);
+    }, [tags, existingNormalizedLabels, onTagsChange]);
+
+    // Handle remove tag
+    const removeTag = useCallback((normalizedLabel) => {
+        onTagsChange(
+            tags.filter(tag => tag.normalizedLabel !== normalizedLabel)
+        );
+    }, [tags, onTagsChange]);
+
+    // Handle key press in input
+    const handleKeyDown = useCallback((e) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            addTag(inputValue);
+            return;
+        }
+
+        if (e.key === 'Escape') {
+            setIsOpen(false);
+            return;
+        }
+
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            setIsOpen(true);
+            return;
+        }
+    }, [inputValue, addTag]);
+
+    // Handle input change
+    const handleInputChange = useCallback((e) => {
+        setInputValue(e.target.value);
+        setIsOpen(true);
+    }, []);
+
+    // Handle input focus
+    const handleInputFocus = useCallback(() => {
+        setIsOpen(true);
+    }, []);
+
+    // Handle suggestion click
+    const handleSuggestionClick = useCallback((label) => {
+        addTag(label);
+        inputRef.current?.focus();
+    }, [addTag]);
+
+    // Close dropdown when clicking outside
+    React.useEffect(() => {
+        const handleClickOutside = (e) => {
+            if (!containerRef.current?.contains(e.target)) {
+                setIsOpen(false);
+            }
+        };
+
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, []);
+
+    const suggestions = filteredSuggestions();
+    const hasNoTags = tags.length === 0;
+    const showPlaceholder = hasNoTags && !inputValue;
+
+    return (
+        <div className="tag-input-container" ref={containerRef}>
+            <div className="tag-input-wrapper">
+                {/* Display current tags as chips */}
+                <div className="tag-chips">
+                    {tags.map(tag => (
+                        <div key={tag.normalizedLabel} className="tag-chip">
+                            <span className="tag-chip-label">{tag.label}</span>
+                            <button
+                                type="button"
+                                className="tag-chip-remove"
+                                onClick={() => removeTag(tag.normalizedLabel)}
+                                disabled={disabled || isLoading}
+                                aria-label={`Remove tag ${tag.label}`}
+                            >
+                                <X size={14} />
+                            </button>
+                        </div>
+                    ))}
+                </div>
+
+                {/* Input field */}
+                <div className="tag-input-field-wrapper">
+                    <input
+                        ref={inputRef}
+                        type="text"
+                        className="tag-input-field"
+                        placeholder={showPlaceholder ? 'Add tags (e.g., Frontend, React)' : ''}
+                        value={inputValue}
+                        onChange={handleInputChange}
+                        onKeyDown={handleKeyDown}
+                        onFocus={handleInputFocus}
+                        disabled={disabled || isLoading}
+                        autoComplete="off"
+                    />
+                    {suggestions.length > 0 && (
+                        <ChevronDown
+                            size={16}
+                            className="tag-input-dropdown-icon"
+                            style={{
+                                transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+                                transition: 'transform 0.2s',
+                            }}
+                        />
+                    )}
+                </div>
+            </div>
+
+            {/* Suggestions dropdown */}
+            {isOpen && suggestions.length > 0 && (
+                <div className="tag-suggestions">
+                    {suggestions.map(tag => (
+                        <button
+                            key={tag.normalizedLabel}
+                            type="button"
+                            className="tag-suggestion-item"
+                            onClick={() => handleSuggestionClick(tag.label)}
+                            disabled={disabled || isLoading}
+                        >
+                            {tag.label}
+                        </button>
+                    ))}
+                </div>
+            )}
+
+            {/* Empty state message */}
+            {isOpen && suggestions.length === 0 && inputValue.trim() && (
+                <div className="tag-empty-state">
+                    <p className="tag-empty-state-text">
+                        Press Enter to create &quot;{inputValue.trim()}&quot;
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/features/manual-roadmap/manualRoadmap.api.js
+++ b/frontend/src/features/manual-roadmap/manualRoadmap.api.js
@@ -51,19 +51,19 @@ export function getManualRoadmap(authToken, roadmapId) {
     return request(`/roadmaps/manual-roadmaps/${roadmapId}`, 'GET', authToken);
 }
 
-export function createManualRoadmap(authToken, { yamlCode }) {
-    return request('/roadmaps/manual-roadmaps', 'POST', authToken, { yamlCode });
+export function createManualRoadmap(authToken, { yamlCode, tags = [] }) {
+    return request('/roadmaps/manual-roadmaps', 'POST', authToken, { yamlCode, tags });
 }
 
-export function updateManualRoadmap(authToken, roadmapId, { yamlCode }) {
-    return request(`/roadmaps/manual-roadmaps/${roadmapId}`, 'PATCH', authToken, { yamlCode });
+export function updateManualRoadmap(authToken, roadmapId, { yamlCode, tags = [] }) {
+    return request(`/roadmaps/manual-roadmaps/${roadmapId}`, 'PATCH', authToken, { yamlCode, tags });
 }
 
 export function shareManualRoadmap(authToken, roadmapId) {
     return request(`/roadmaps/manual-roadmaps/${roadmapId}/share`, 'POST', authToken);
 }
 
-export function listPublicManualRoadmaps({ q = '', page = 1, limit = 20 } = {}) {
+export function listPublicManualRoadmaps({ q = '', tags = [], page = 1, limit = 20 } = {}) {
     const params = new URLSearchParams({
         page: String(page),
         limit: String(limit),
@@ -74,7 +74,17 @@ export function listPublicManualRoadmaps({ q = '', page = 1, limit = 20 } = {}) 
         params.set('q', normalizedQuery);
     }
 
+    if (Array.isArray(tags) && tags.length > 0) {
+        tags.forEach(tag => {
+            params.append('tags', String(tag || '').trim().toLowerCase());
+        });
+    }
+
     return request(`/roadmaps/manual-roadmaps/public?${params.toString()}`, 'GET', null, undefined, { requireAuth: false });
+}
+
+export function getManualRoadmapTags() {
+    return request('/roadmaps/manual-roadmaps/tags', 'GET', null, undefined, { requireAuth: false });
 }
 
 export function getPublicManualRoadmapPreviewById(roadmapId) {
@@ -89,6 +99,7 @@ const manualRoadmapApi = {
     shareManualRoadmap,
     listPublicManualRoadmaps,
     getPublicManualRoadmapPreviewById,
+    getManualRoadmapTags,
 };
 
 export default manualRoadmapApi;

--- a/frontend/src/features/manual-roadmap/tag-input.css
+++ b/frontend/src/features/manual-roadmap/tag-input.css
@@ -1,0 +1,249 @@
+/* Tag Input Component Styles */
+
+.tag-input-container {
+    position: relative;
+    width: 100%;
+}
+
+.tag-input-wrapper {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.625rem 0.75rem;
+    border: 1px solid var(--color-border, #e5e7eb);
+    border-radius: 0.375rem;
+    background-color: var(--color-background, #ffffff);
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.tag-input-wrapper:focus-within {
+    border-color: var(--color-primary, #3b82f6);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.tag-input-wrapper:hover:not(:focus-within) {
+    border-color: var(--color-border-hover, #d1d5db);
+}
+
+/* Tag Chips Display */
+.tag-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    flex: 0 1 auto;
+}
+
+.tag-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.375rem 0.625rem;
+    border-radius: 0.25rem;
+    background-color: var(--color-tag-bg, #dbeafe);
+    border: 1px solid var(--color-tag-border, #93c5fd);
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-tag-text, #1e40af);
+    white-space: nowrap;
+    animation: slideIn 0.2s ease-out;
+}
+
+@keyframes slideIn {
+    from {
+        opacity: 0;
+        transform: scale(0.95);
+    }
+
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+.tag-chip-label {
+    max-width: 200px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tag-chip-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
+    color: inherit;
+    opacity: 0.7;
+    transition: opacity 0.2s;
+}
+
+.tag-chip-remove:hover:not(:disabled) {
+    opacity: 1;
+}
+
+.tag-chip-remove:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+/* Input Field */
+.tag-input-field-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    flex: 1 1 150px;
+    min-width: 150px;
+}
+
+.tag-input-field {
+    flex: 1;
+    border: none;
+    background: transparent;
+    padding: 0;
+    outline: none;
+    font-size: 0.875rem;
+    font-family: inherit;
+    color: var(--color-text, #1f2937);
+    min-width: 100px;
+}
+
+.tag-input-field::placeholder {
+    color: var(--color-text-placeholder, #9ca3af);
+}
+
+.tag-input-field:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.tag-input-dropdown-icon {
+    position: absolute;
+    right: 0;
+    pointer-events: none;
+    color: var(--color-text-secondary, #6b7280);
+    opacity: 0.5;
+}
+
+/* Suggestions Dropdown */
+.tag-suggestions {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin-top: 0.25rem;
+    border: 1px solid var(--color-border, #e5e7eb);
+    border-radius: 0.375rem;
+    background-color: var(--color-background, #ffffff);
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+    max-height: 256px;
+    overflow-y: auto;
+    z-index: 10;
+    animation: dropdownIn 0.15s ease-out;
+}
+
+@keyframes dropdownIn {
+    from {
+        opacity: 0;
+        transform: translateY(-0.5rem);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.tag-suggestion-item {
+    display: block;
+    width: 100%;
+    padding: 0.625rem 0.75rem;
+    border: none;
+    background: transparent;
+    text-align: left;
+    cursor: pointer;
+    color: var(--color-text, #1f2937);
+    font-size: 0.875rem;
+    transition: background-color 0.15s;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.tag-suggestion-item:hover:not(:disabled) {
+    background-color: var(--color-hover-bg, #f3f4f6);
+}
+
+.tag-suggestion-item:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+/* Empty State */
+.tag-empty-state {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin-top: 0.25rem;
+    padding: 0.75rem;
+    border: 1px solid var(--color-border, #e5e7eb);
+    border-radius: 0.375rem;
+    background-color: var(--color-background, #ffffff);
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+    z-index: 10;
+    animation: dropdownIn 0.15s ease-out;
+}
+
+.tag-empty-state-text {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-secondary, #6b7280);
+    font-style: italic;
+}
+
+/* Dark mode support */
+:root[data-theme='dark'] .tag-input-wrapper {
+    border-color: var(--color-border, #374151);
+    background-color: var(--color-background, #1f2937);
+}
+
+:root[data-theme='dark'] .tag-input-wrapper:focus-within {
+    border-color: var(--color-primary, #60a5fa);
+    box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.1);
+}
+
+:root[data-theme='dark'] .tag-chip {
+    background-color: var(--color-tag-bg, #1e3a8a);
+    border-color: var(--color-tag-border, #1e40af);
+    color: var(--color-tag-text, #93c5fd);
+}
+
+:root[data-theme='dark'] .tag-input-field {
+    color: var(--color-text, #f3f4f6);
+}
+
+:root[data-theme='dark'] .tag-input-field::placeholder {
+    color: var(--color-text-placeholder, #6b7280);
+}
+
+:root[data-theme='dark'] .tag-suggestions,
+:root[data-theme='dark'] .tag-empty-state {
+    border-color: var(--color-border, #374151);
+    background-color: var(--color-background, #1f2937);
+}
+
+:root[data-theme='dark'] .tag-suggestion-item {
+    color: var(--color-text, #f3f4f6);
+}
+
+:root[data-theme='dark'] .tag-suggestion-item:hover:not(:disabled) {
+    background-color: var(--color-hover-bg, #374151);
+}
+
+:root[data-theme='dark'] .tag-empty-state-text {
+    color: var(--color-text-secondary, #9ca3af);
+}

--- a/frontend/src/features/roadmap-search/RoadmapSearchPage.jsx
+++ b/frontend/src/features/roadmap-search/RoadmapSearchPage.jsx
@@ -54,6 +54,59 @@ export default function RoadmapSearchPage() {
         }
     }, []);
 
+    useEffect(() => {
+        /** Bỏ qua điều hướng kết quả: ô tag sau #, textarea/select, hoặc nút trong dropdown gợi ý tag. */
+        function shouldSkipResultArrowNav(el) {
+            if (!el || !(el instanceof HTMLElement)) {
+                return true;
+            }
+            if (el.isContentEditable) {
+                return true;
+            }
+            const tag = el.tagName;
+            if (tag === 'TEXTAREA' || tag === 'SELECT') {
+                return true;
+            }
+            if (tag === 'INPUT') {
+                if (el.classList.contains('roadmap-search-query-bar__tag-input')) {
+                    return true;
+                }
+                if (el.getAttribute('name') === 'roadmap-search-tag-draft') {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        function onKeyDown(e) {
+            if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') {
+                return;
+            }
+            const target = e.target;
+            if (target instanceof HTMLElement && target.closest?.('.roadmap-search-query-bar__suggestions')) {
+                return;
+            }
+            if (shouldSkipResultArrowNav(target)) {
+                return;
+            }
+            if (results.length === 0 || resultsStatus !== 'loaded') {
+                return;
+            }
+            e.preventDefault();
+            const idx = results.findIndex((r) => r._id === selectedRoadmapId);
+            let nextIdx;
+            if (e.key === 'ArrowDown') {
+                nextIdx = idx < 0 ? 0 : (idx + 1) % results.length;
+            } else {
+                nextIdx = idx <= 0 ? results.length - 1 : idx - 1;
+            }
+            setSelectedRoadmapId(results[nextIdx]._id);
+        }
+
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [results, resultsStatus, selectedRoadmapId, setSelectedRoadmapId]);
+
     return (
         <div className="roadmap-search-page">
             <section className="roadmap-search-page__left">

--- a/frontend/src/features/roadmap-search/RoadmapSearchPage.jsx
+++ b/frontend/src/features/roadmap-search/RoadmapSearchPage.jsx
@@ -1,14 +1,24 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import RoadmapSearchResults from './RoadmapSearchResults';
+import RoadmapSearchQueryBar from './RoadmapSearchQueryBar';
 import RoadmapPreviewPanel from './RoadmapPreviewPanel';
+import roadmapSearchApi from '../../services/roadmapSearch.api';
 import { useRoadmapSearch } from './useRoadmapSearch';
 
-export const ROADMAP_SEARCH_PLACEHOLDER = 'Search roadmap by name...';
+export const ROADMAP_SEARCH_PLACEHOLDER =
+    'Tìm theo tên… Gõ # để gắn tag, Enter để xác nhận tag.';
 export const ROADMAP_SEARCH_DEBOUNCE_MS = 300;
 export const ROADMAP_SEARCH_MIN_LENGTH = 2;
 
 export default function RoadmapSearchPage() {
+    const queryAnchorRef = useRef(null);
+    const queryInputRef = useRef(null);
+    const [availableTags, setAvailableTags] = useState([]);
     const {
+        nameQuery,
+        setNameQuery,
+        selectedTags,
+        setSelectedTags,
         results,
         selectedRoadmapId,
         setSelectedRoadmapId,
@@ -19,26 +29,60 @@ export default function RoadmapSearchPage() {
     } = useRoadmapSearch('');
 
     useEffect(() => {
-        const navbarInput = window.document.querySelector('.navbar__input');
-        if (navbarInput && typeof navbarInput.focus === 'function') {
-            navbarInput.focus();
+        let cancelled = false;
+        roadmapSearchApi
+            .getManualRoadmapTags()
+            .then((tags) => {
+                if (!cancelled && Array.isArray(tags)) {
+                    setAvailableTags(tags);
+                }
+            })
+            .catch(() => {});
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    useLayoutEffect(() => {
+        const anchor = queryAnchorRef.current;
+        const input = queryInputRef.current;
+        if (anchor && typeof anchor.scrollIntoView === 'function') {
+            anchor.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+        if (input && typeof input.focus === 'function') {
+            input.focus({ preventScroll: true });
         }
     }, []);
 
     return (
         <div className="roadmap-search-page">
             <section className="roadmap-search-page__left">
+                <div
+                    ref={queryAnchorRef}
+                    id="roadmap-search-query-anchor"
+                    className="roadmap-search-page__query"
+                    role="search"
+                    aria-label="Tìm kiếm roadmap"
+                >
+                    <RoadmapSearchQueryBar
+                        nameQuery={nameQuery}
+                        setNameQuery={setNameQuery}
+                        selectedTags={selectedTags}
+                        setSelectedTags={setSelectedTags}
+                        availableTags={availableTags}
+                        inputRef={queryInputRef}
+                        placeholder={ROADMAP_SEARCH_PLACEHOLDER}
+                    />
+                </div>
                 <div className="roadmap-search-page__section-header">
                     <div>
                         <h2 className="roadmap-search-page__title">Roadmaps</h2>
                         <p className="roadmap-search-page__subtitle">
-                            Find public manual roadmaps by name, then preview them on the right.
+                            Tìm roadmap công khai theo tên và tag; xem trước bên phải.
                         </p>
                     </div>
                 </div>
-                {errorMessage ? (
-                    <p className="roadmap-search-page__error">{errorMessage}</p>
-                ) : null}
+                {errorMessage ? <p className="roadmap-search-page__error">{errorMessage}</p> : null}
                 <RoadmapSearchResults
                     results={results}
                     resultsStatus={resultsStatus}

--- a/frontend/src/features/roadmap-search/RoadmapSearchPage.test.jsx
+++ b/frontend/src/features/roadmap-search/RoadmapSearchPage.test.jsx
@@ -1,6 +1,6 @@
 describe('RoadmapSearchPage shell constants', () => {
     test('defines search placeholder for autofocus entry input', () => {
-        expect('Search roadmap by name...').toBe('Search roadmap by name...');
+        expect('Tìm theo tên… Gõ # để gắn tag, Enter để xác nhận tag.').toMatch(/#/);
     });
 
     test('uses configured debounce and min-length constraints', async () => {

--- a/frontend/src/features/roadmap-search/RoadmapSearchQueryBar.jsx
+++ b/frontend/src/features/roadmap-search/RoadmapSearchQueryBar.jsx
@@ -56,6 +56,28 @@ export default function RoadmapSearchQueryBar({
             .slice(0, 8);
     }, [availableTags, tagDraft, selectedTags]);
 
+    /** Thứ tự đúng với DOM: catalog trước, dòng “Thêm …” sau (nếu có). */
+    const suggestionOptions = useMemo(() => {
+        const opts = filteredSuggestions.map((tag) => ({
+            kind: 'catalog',
+            label: tag.label,
+        }));
+        const trimmed = String(tagDraft || '').trim();
+        if (
+            trimmed &&
+            !filteredSuggestions.some((t) => t.label.toLowerCase() === trimmed.toLowerCase())
+        ) {
+            opts.push({ kind: 'free', label: trimmed });
+        }
+        return opts;
+    }, [filteredSuggestions, tagDraft]);
+
+    const [suggestionHighlightIndex, setSuggestionHighlightIndex] = useState(0);
+
+    useEffect(() => {
+        setSuggestionHighlightIndex(0);
+    }, [suggestionOptions]);
+
     const commitTag = useCallback(
         (rawLabel) => {
             const trimmed = String(rawLabel || '').trim();
@@ -124,8 +146,24 @@ export default function RoadmapSearchQueryBar({
 
     const handleTagKeyDown = useCallback(
         (event) => {
+            const len = suggestionOptions.length;
+            if (event.key === 'ArrowDown' && len > 0) {
+                event.preventDefault();
+                setSuggestionHighlightIndex((i) => Math.min(i + 1, len - 1));
+                return;
+            }
+            if (event.key === 'ArrowUp' && len > 0) {
+                event.preventDefault();
+                setSuggestionHighlightIndex((i) => Math.max(i - 1, 0));
+                return;
+            }
             if (event.key === 'Enter') {
                 event.preventDefault();
+                const pick = suggestionOptions[suggestionHighlightIndex];
+                if (pick) {
+                    commitTag(pick.label);
+                    return;
+                }
                 commitTag(tagDraft);
                 return;
             }
@@ -134,7 +172,7 @@ export default function RoadmapSearchQueryBar({
                 setTagDraft(null);
             }
         },
-        [commitTag, tagDraft]
+        [commitTag, suggestionHighlightIndex, suggestionOptions, tagDraft]
     );
 
     useLayoutEffect(() => {
@@ -253,13 +291,15 @@ export default function RoadmapSearchQueryBar({
                                 role="listbox"
                                 aria-label="Gợi ý tag"
                             >
-                                {filteredSuggestions.map((tag) => (
+                                {filteredSuggestions.map((tag, idx) => (
                                     <button
                                         key={tag.normalizedLabel}
                                         type="button"
                                         role="option"
-                                        className="roadmap-search-query-bar__suggestion"
+                                        aria-selected={idx === suggestionHighlightIndex}
+                                        className={`roadmap-search-query-bar__suggestion${idx === suggestionHighlightIndex ? ' roadmap-search-query-bar__suggestion--keyboard-active' : ''}`}
                                         onMouseDown={(e) => e.preventDefault()}
+                                        onMouseEnter={() => setSuggestionHighlightIndex(idx)}
                                         onClick={() => commitTag(tag.label)}
                                     >
                                         {tag.label}
@@ -272,8 +312,14 @@ export default function RoadmapSearchQueryBar({
                                     <button
                                         type="button"
                                         role="option"
-                                        className="roadmap-search-query-bar__suggestion roadmap-search-query-bar__suggestion--free"
+                                        aria-selected={
+                                            suggestionHighlightIndex === filteredSuggestions.length
+                                        }
+                                        className={`roadmap-search-query-bar__suggestion roadmap-search-query-bar__suggestion--free${suggestionHighlightIndex === filteredSuggestions.length ? ' roadmap-search-query-bar__suggestion--keyboard-active' : ''}`}
                                         onMouseDown={(e) => e.preventDefault()}
+                                        onMouseEnter={() =>
+                                            setSuggestionHighlightIndex(filteredSuggestions.length)
+                                        }
                                         onClick={() => commitTag(tagDraft)}
                                     >
                                         Thêm “{String(tagDraft).trim()}”

--- a/frontend/src/features/roadmap-search/RoadmapSearchQueryBar.jsx
+++ b/frontend/src/features/roadmap-search/RoadmapSearchQueryBar.jsx
@@ -1,0 +1,306 @@
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Search, X } from 'lucide-react';
+
+function existingNormalizedSet(tags = []) {
+    return new Set(tags.map((t) => String(t?.normalizedLabel || '').trim().toLowerCase()).filter(Boolean));
+}
+
+function assignRef(ref, el) {
+    if (!ref) {
+        return;
+    }
+    if (typeof ref === 'function') {
+        ref(el);
+    } else {
+        ref.current = el;
+    }
+}
+
+/**
+ * Tìm theo tên; gõ `#` để nhập tag trong vùng riêng (highlight chỉ phần sau #).
+ */
+export default function RoadmapSearchQueryBar({
+    nameQuery,
+    setNameQuery,
+    selectedTags = [],
+    setSelectedTags,
+    availableTags = [],
+    inputRef: externalInputRef,
+    placeholder = '',
+}) {
+    const [tagDraft, setTagDraft] = useState(null);
+    const combinedRef = useRef(null);
+    const nameInputRef = useRef(null);
+    const tagInputRef = useRef(null);
+    const suggestionsRef = useRef(null);
+    const prevTagDraftRef = useRef(null);
+
+    const filteredSuggestions = useMemo(() => {
+        const selectedNormalized = existingNormalizedSet(selectedTags);
+        if (tagDraft === null) {
+            return [];
+        }
+        const needle = String(tagDraft).trim().toLowerCase();
+        return availableTags
+            .filter((tag) => {
+                const nl = String(tag?.normalizedLabel || '').toLowerCase();
+                const lb = String(tag?.label || '').toLowerCase();
+                if (selectedNormalized.has(nl)) {
+                    return false;
+                }
+                if (!needle) {
+                    return true;
+                }
+                return lb.includes(needle) || nl.includes(needle);
+            })
+            .slice(0, 8);
+    }, [availableTags, tagDraft, selectedTags]);
+
+    const commitTag = useCallback(
+        (rawLabel) => {
+            const trimmed = String(rawLabel || '').trim();
+            if (!trimmed) {
+                setTagDraft(null);
+                return;
+            }
+            const lower = trimmed.toLowerCase();
+            const fromCatalog = availableTags.find(
+                (t) =>
+                    String(t?.normalizedLabel || '').toLowerCase() === lower ||
+                    String(t?.label || '').trim().toLowerCase() === lower
+            );
+            const next = fromCatalog
+                ? { label: fromCatalog.label, normalizedLabel: String(fromCatalog.normalizedLabel || '').toLowerCase() }
+                : { label: trimmed, normalizedLabel: lower };
+
+            setSelectedTags((prev) => {
+                const taken = existingNormalizedSet(prev);
+                if (taken.has(next.normalizedLabel)) {
+                    return prev;
+                }
+                return [...prev, next];
+            });
+            setTagDraft(null);
+        },
+        [availableTags, setSelectedTags]
+    );
+
+    const removeTag = useCallback(
+        (normalizedLabel) => {
+            setSelectedTags((prev) => prev.filter((t) => t.normalizedLabel !== normalizedLabel));
+        },
+        [setSelectedTags]
+    );
+
+    const handleCombinedChange = useCallback(
+        (event) => {
+            const v = event.target.value;
+            const idx = v.lastIndexOf('#');
+            if (idx === -1) {
+                setNameQuery(v);
+                setTagDraft(null);
+                return;
+            }
+            setNameQuery(v.slice(0, idx));
+            setTagDraft(v.slice(idx + 1));
+        },
+        [setNameQuery]
+    );
+
+    const handleCombinedKeyDown = useCallback(
+        (event) => {
+            if (event.key === 'Enter' && tagDraft !== null) {
+                event.preventDefault();
+                commitTag(tagDraft);
+                return;
+            }
+            if (event.key === 'Escape' && tagDraft !== null) {
+                event.preventDefault();
+                setTagDraft(null);
+            }
+        },
+        [commitTag, tagDraft]
+    );
+
+    const handleTagKeyDown = useCallback(
+        (event) => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                commitTag(tagDraft);
+                return;
+            }
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                setTagDraft(null);
+            }
+        },
+        [commitTag, tagDraft]
+    );
+
+    useLayoutEffect(() => {
+        const prev = prevTagDraftRef.current;
+        prevTagDraftRef.current = tagDraft;
+        if (tagDraft !== null && prev === null) {
+            window.requestAnimationFrame(() => tagInputRef.current?.focus());
+        }
+        if (tagDraft === null && prev !== null) {
+            window.requestAnimationFrame(() => combinedRef.current?.focus());
+        }
+    }, [tagDraft]);
+
+    useEffect(() => {
+        function handlePointerDown(event) {
+            if (tagDraft === null) {
+                return;
+            }
+            const t = event.target;
+            const inside =
+                nameInputRef.current?.contains(t) ||
+                tagInputRef.current?.contains(t) ||
+                suggestionsRef.current?.contains(t);
+            if (inside) {
+                return;
+            }
+            setTagDraft(null);
+        }
+
+        document.addEventListener('mousedown', handlePointerDown);
+        return () => document.removeEventListener('mousedown', handlePointerDown);
+    }, [tagDraft]);
+
+    const showSuggestions = tagDraft !== null;
+    const isSplit = tagDraft !== null;
+
+    const setCombinedEl = useCallback(
+        (el) => {
+            combinedRef.current = el;
+            assignRef(externalInputRef, el);
+        },
+        [externalInputRef]
+    );
+
+    const setNameEl = useCallback(
+        (el) => {
+            nameInputRef.current = el;
+            assignRef(externalInputRef, el);
+        },
+        [externalInputRef]
+    );
+
+    return (
+        <div className="roadmap-search-query-bar">
+            <div className="roadmap-search-query-bar__shell">
+                <div className="roadmap-search-query-bar__row">
+                    <Search className="roadmap-search-page__query-icon" size={18} aria-hidden="true" />
+                    <div className="roadmap-search-query-bar__field-wrap">
+                        {!isSplit ? (
+                            <input
+                                ref={setCombinedEl}
+                                className="roadmap-search-page__input roadmap-search-page__input--full"
+                                type="text"
+                                name="roadmap-search-query"
+                                placeholder={placeholder}
+                                autoComplete="off"
+                                autoCorrect="off"
+                                spellCheck={false}
+                                value={nameQuery}
+                                onChange={handleCombinedChange}
+                                onKeyDown={handleCombinedKeyDown}
+                                aria-expanded={false}
+                            />
+                        ) : (
+                            <div className="roadmap-search-query-bar__split" role="group" aria-label="Tìm kiếm và tag">
+                                <input
+                                    ref={setNameEl}
+                                    className="roadmap-search-page__input roadmap-search-page__input--name-part"
+                                    type="text"
+                                    name="roadmap-search-name"
+                                    autoComplete="off"
+                                    autoCorrect="off"
+                                    spellCheck={false}
+                                    value={nameQuery}
+                                    onChange={(e) => setNameQuery(e.target.value)}
+                                    aria-label="Từ khóa tên roadmap"
+                                />
+                                <span className="roadmap-search-query-bar__hash" aria-hidden="true">
+                                    #
+                                </span>
+                                <div className="roadmap-search-query-bar__tag-zone">
+                                    <input
+                                        ref={tagInputRef}
+                                        className="roadmap-search-query-bar__tag-input"
+                                        type="text"
+                                        name="roadmap-search-tag-draft"
+                                        autoComplete="off"
+                                        autoCorrect="off"
+                                        spellCheck={false}
+                                        value={tagDraft}
+                                        onChange={(e) => setTagDraft(e.target.value)}
+                                        onKeyDown={handleTagKeyDown}
+                                        placeholder="tag…"
+                                        aria-label="Nhập tag sau dấu #"
+                                        aria-controls={showSuggestions ? 'roadmap-search-tag-suggestions' : undefined}
+                                        aria-expanded={showSuggestions}
+                                    />
+                                </div>
+                            </div>
+                        )}
+                        {showSuggestions ? (
+                            <div
+                                ref={suggestionsRef}
+                                id="roadmap-search-tag-suggestions"
+                                className="roadmap-search-query-bar__suggestions"
+                                role="listbox"
+                                aria-label="Gợi ý tag"
+                            >
+                                {filteredSuggestions.map((tag) => (
+                                    <button
+                                        key={tag.normalizedLabel}
+                                        type="button"
+                                        role="option"
+                                        className="roadmap-search-query-bar__suggestion"
+                                        onMouseDown={(e) => e.preventDefault()}
+                                        onClick={() => commitTag(tag.label)}
+                                    >
+                                        {tag.label}
+                                    </button>
+                                ))}
+                                {String(tagDraft || '').trim().length > 0 &&
+                                !filteredSuggestions.some(
+                                    (t) => t.label.toLowerCase() === String(tagDraft).trim().toLowerCase()
+                                ) ? (
+                                    <button
+                                        type="button"
+                                        role="option"
+                                        className="roadmap-search-query-bar__suggestion roadmap-search-query-bar__suggestion--free"
+                                        onMouseDown={(e) => e.preventDefault()}
+                                        onClick={() => commitTag(tagDraft)}
+                                    >
+                                        Thêm “{String(tagDraft).trim()}”
+                                    </button>
+                                ) : null}
+                            </div>
+                        ) : null}
+                    </div>
+                </div>
+            </div>
+            {selectedTags.length > 0 ? (
+                <div className="roadmap-search-query-bar__chips" aria-label="Tag đang lọc">
+                    {selectedTags.map((tag) => (
+                        <span key={tag.normalizedLabel} className="roadmap-search-query-bar__chip">
+                            <span className="roadmap-search-query-bar__chip-label">{tag.label}</span>
+                            <button
+                                type="button"
+                                className="roadmap-search-query-bar__chip-remove"
+                                aria-label={`Xóa tag ${tag.label}`}
+                                onClick={() => removeTag(tag.normalizedLabel)}
+                            >
+                                <X size={14} aria-hidden="true" />
+                            </button>
+                        </span>
+                    ))}
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/frontend/src/features/roadmap-search/RoadmapSearchResults.jsx
+++ b/frontend/src/features/roadmap-search/RoadmapSearchResults.jsx
@@ -16,11 +16,14 @@ export default function RoadmapSearchResults({ results = [], resultsStatus = 'id
     return (
         <div className="roadmap-search-results" aria-label="Roadmap search results">
             {results.length === 0 ? (
-                <p className="roadmap-search-results__state">Type at least 2 characters to search.</p>
+                <p className="roadmap-search-results__state">
+                    Nhập ít nhất 2 ký tự tên hoặc chọn tag (#) để tìm.
+                </p>
             ) : (
                 <div className="roadmap-search-results__list">
                     {results.map((result) => {
                         const isSelected = result._id === selectedRoadmapId;
+                        const tags = Array.isArray(result.tags) ? result.tags : [];
                         return (
                             <button
                                 key={result._id}
@@ -30,6 +33,18 @@ export default function RoadmapSearchResults({ results = [], resultsStatus = 'id
                             >
                                 <div className="roadmap-search-results__card-body">
                                     <strong className="roadmap-search-results__card-title">{result.title}</strong>
+                                    {tags.length > 0 ? (
+                                        <div className="roadmap-search-results__tags" aria-label="Tags">
+                                            {tags.map((tag) => (
+                                                <span
+                                                    key={String(tag.normalizedLabel || tag.label || '')}
+                                                    className="roadmap-search-results__tag"
+                                                >
+                                                    {tag.label || tag.normalizedLabel}
+                                                </span>
+                                            ))}
+                                        </div>
+                                    ) : null}
                                     <p className="roadmap-search-results__card-description">{result.description || 'No description'}</p>
                                 </div>
                             </button>

--- a/frontend/src/features/roadmap-search/RoadmapSearchResults.jsx
+++ b/frontend/src/features/roadmap-search/RoadmapSearchResults.jsx
@@ -1,6 +1,18 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 export default function RoadmapSearchResults({ results = [], resultsStatus = 'idle', selectedRoadmapId = null, onSelectResult }) {
+    const listRef = useRef(null);
+
+    useEffect(() => {
+        if (!selectedRoadmapId || !listRef.current) {
+            return;
+        }
+        const id = String(selectedRoadmapId);
+        const card = Array.from(listRef.current.querySelectorAll('[data-result-id]')).find(
+            (el) => el.getAttribute('data-result-id') === id
+        );
+        card?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }, [selectedRoadmapId, results]);
     if (resultsStatus === 'searching') {
         return <p className="roadmap-search-results__state">Searching roadmaps...</p>;
     }
@@ -20,7 +32,7 @@ export default function RoadmapSearchResults({ results = [], resultsStatus = 'id
                     Nhập ít nhất 2 ký tự tên hoặc chọn tag (#) để tìm.
                 </p>
             ) : (
-                <div className="roadmap-search-results__list">
+                <div ref={listRef} className="roadmap-search-results__list" role="listbox" aria-label="Danh sách roadmap">
                     {results.map((result) => {
                         const isSelected = result._id === selectedRoadmapId;
                         const tags = Array.isArray(result.tags) ? result.tags : [];
@@ -28,6 +40,9 @@ export default function RoadmapSearchResults({ results = [], resultsStatus = 'id
                             <button
                                 key={result._id}
                                 type="button"
+                                role="option"
+                                aria-selected={isSelected}
+                                data-result-id={result._id}
                                 className={`roadmap-search-results__card ${isSelected ? 'is-selected' : ''}`}
                                 onClick={() => onSelectResult?.(result._id)}
                             >

--- a/frontend/src/features/roadmap-search/roadmapSearch.logic.js
+++ b/frontend/src/features/roadmap-search/roadmapSearch.logic.js
@@ -6,6 +6,27 @@ export function canSearchRoadmaps(query) {
     return normalizeRoadmapQuery(query).length >= 2;
 }
 
+/** Stable key for dependency arrays when filtering by selected tags. */
+export function selectedTagsSignature(tags = []) {
+    if (!Array.isArray(tags)) {
+        return '';
+    }
+    const labels = tags
+        .map((t) => String(t?.normalizedLabel || '').trim().toLowerCase())
+        .filter(Boolean);
+    return [...new Set(labels)].sort().join('|');
+}
+
+/** Run API search when name query is long enough or at least one tag filter is set. */
+export function shouldRunRoadmapSearch(nameQuery, tags = []) {
+    const q = normalizeRoadmapQuery(nameQuery);
+    const hasTags = Array.isArray(tags) && tags.length > 0;
+    if (hasTags) {
+        return true;
+    }
+    return q.length >= 2;
+}
+
 export function getInitialSelectedRoadmapId(results) {
     return Array.isArray(results) && results.length > 0 ? results[0]._id : null;
 }

--- a/frontend/src/features/roadmap-search/useRoadmapSearch.js
+++ b/frontend/src/features/roadmap-search/useRoadmapSearch.js
@@ -1,11 +1,17 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import roadmapSearchApi from '../../services/roadmapSearch.api';
-import { canSearchRoadmaps, getInitialSelectedRoadmapId, normalizeRoadmapQuery } from './roadmapSearch.logic';
+import {
+    getInitialSelectedRoadmapId,
+    normalizeRoadmapQuery,
+    selectedTagsSignature,
+    shouldRunRoadmapSearch,
+} from './roadmapSearch.logic';
 
 const DEBOUNCE_MS = 300;
 
 export function useRoadmapSearch(initialQuery = '') {
-    const [query, setQuery] = useState(initialQuery);
+    const [nameQuery, setNameQuery] = useState(initialQuery);
+    const [selectedTags, setSelectedTags] = useState([]);
     const [results, setResults] = useState([]);
     const [selectedRoadmapId, setSelectedRoadmapId] = useState(null);
     const [resultsStatus, setResultsStatus] = useState('idle');
@@ -14,7 +20,8 @@ export function useRoadmapSearch(initialQuery = '') {
     const [errorMessage, setErrorMessage] = useState('');
     const requestRef = useRef(0);
 
-    const normalizedQuery = useMemo(() => normalizeRoadmapQuery(query), [query]);
+    const normalizedNameQuery = useMemo(() => normalizeRoadmapQuery(nameQuery), [nameQuery]);
+    const tagsKey = useMemo(() => selectedTagsSignature(selectedTags), [selectedTags]);
 
     useEffect(() => {
         if (typeof window === 'undefined') {
@@ -24,12 +31,12 @@ export function useRoadmapSearch(initialQuery = '') {
         const params = new URLSearchParams(window.location.search);
         const initialUrlQuery = String(params.get('q') || '').trim();
         if (initialUrlQuery) {
-            setQuery(initialUrlQuery);
+            setNameQuery(initialUrlQuery);
         }
 
         const handleNavbarQuery = (event) => {
             const nextQuery = String(event?.detail?.query || '');
-            setQuery(nextQuery);
+            setNameQuery(nextQuery);
         };
 
         window.addEventListener('roadmap-search-query', handleNavbarQuery);
@@ -40,7 +47,10 @@ export function useRoadmapSearch(initialQuery = '') {
     }, []);
 
     useEffect(() => {
-        if (normalizedQuery.length === 0) {
+        const q = normalizedNameQuery;
+        const hasTags = Array.isArray(selectedTags) && selectedTags.length > 0;
+
+        if (q.length === 0 && !hasTags) {
             setResults([]);
             setSelectedRoadmapId(null);
             setResultsStatus('idle');
@@ -50,15 +60,20 @@ export function useRoadmapSearch(initialQuery = '') {
             return;
         }
 
-        if (!canSearchRoadmaps(normalizedQuery)) {
+        if (!shouldRunRoadmapSearch(nameQuery, selectedTags)) {
             setResults([]);
             setSelectedRoadmapId(null);
             setResultsStatus('idle');
             setPreviewStatus('idle');
             setPreviewData(null);
-            setErrorMessage('Type at least 2 characters to search.');
+            setErrorMessage('Nhập ít nhất 2 ký tự để tìm theo tên (hoặc chọn tag).');
             return;
         }
+
+        const qParam = q.length >= 2 ? q : '';
+        const tagsParam = Array.isArray(selectedTags)
+            ? selectedTags.map((t) => String(t?.normalizedLabel || '').trim().toLowerCase()).filter(Boolean)
+            : [];
 
         const requestId = requestRef.current + 1;
         requestRef.current = requestId;
@@ -67,7 +82,12 @@ export function useRoadmapSearch(initialQuery = '') {
 
         const timer = window.setTimeout(async () => {
             try {
-                const payload = await roadmapSearchApi.searchPublicRoadmaps({ q: normalizedQuery, page: 1, limit: 20 });
+                const payload = await roadmapSearchApi.searchPublicRoadmaps({
+                    q: qParam,
+                    tags: tagsParam,
+                    page: 1,
+                    limit: 20,
+                });
                 if (requestRef.current !== requestId) {
                     return;
                 }
@@ -125,7 +145,7 @@ export function useRoadmapSearch(initialQuery = '') {
         return () => {
             window.clearTimeout(timer);
         };
-    }, [normalizedQuery]);
+    }, [normalizedNameQuery, tagsKey]);
 
     useEffect(() => {
         if (!selectedRoadmapId) {
@@ -160,8 +180,13 @@ export function useRoadmapSearch(initialQuery = '') {
     }, [selectedRoadmapId]);
 
     return {
-        query,
-        setQuery,
+        nameQuery,
+        setNameQuery,
+        selectedTags,
+        setSelectedTags,
+        /** @deprecated same as nameQuery — kept for callers using `query` */
+        query: nameQuery,
+        setQuery: setNameQuery,
         results,
         selectedRoadmapId,
         setSelectedRoadmapId,

--- a/frontend/src/services/roadmapSearch.api.js
+++ b/frontend/src/services/roadmapSearch.api.js
@@ -27,12 +27,21 @@ async function request(path, method = 'GET') {
     return payload;
 }
 
-export function searchPublicRoadmaps({ q = '', page = 1, limit = 20 } = {}) {
+export function searchPublicRoadmaps({ q = '', tags = [], page = 1, limit = 20 } = {}) {
     const params = new URLSearchParams({ page: String(page), limit: String(limit) });
     if (q) {
         params.set('q', q);
     }
+    if (Array.isArray(tags) && tags.length > 0) {
+        tags.forEach(tag => {
+            params.append('tags', String(tag || '').trim().toLowerCase());
+        });
+    }
     return request(`/roadmaps/manual-roadmaps/public?${params.toString()}`, 'GET');
+}
+
+export function getManualRoadmapTags() {
+    return request('/roadmaps/manual-roadmaps/tags', 'GET');
 }
 
 export function getPublicRoadmapPreviewById(roadmapId) {
@@ -42,6 +51,7 @@ export function getPublicRoadmapPreviewById(roadmapId) {
 const roadmapSearchApi = {
     searchPublicRoadmaps,
     getPublicRoadmapPreviewById,
+    getManualRoadmapTags,
 };
 
 export default roadmapSearchApi;

--- a/frontend/src/shared/RoadmapGraphRenderer.jsx
+++ b/frontend/src/shared/RoadmapGraphRenderer.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNotification } from '../features/general/NotificationContainer';
+import { useNotification } from '../features/notification/NotificationContainer';
 import './roadmapGraphRenderer.css';
 
 /**

--- a/frontend/src/style/general-component.css
+++ b/frontend/src/style/general-component.css
@@ -172,59 +172,9 @@ html[data-theme='dark'] .navbar__link:hover {
   color: #e8f2ff;
 }
 
-.navbar__search {
-  position: relative;
-  max-width: 46rem;
-  cursor: text;
-  flex: 0 1 22rem;
-  width: min(100%, 22rem);
+.navbar__search-trigger {
   margin-left: 0.45rem;
-}
-
-.navbar__search-icon {
-  position: absolute;
-  left: 0.9rem;
-  top: 50%;
-  transform: translateY(-50%);
-  color: #7b8498;
-  pointer-events: none;
-  z-index: 1;
-}
-
-html[data-theme='dark'] .navbar__search-icon {
-  color: #8eb4e8;
-}
-
-.navbar__input {
-  width: 100%;
-  height: 34px;
-  padding: 0.35rem 0.8rem 0.35rem 2.75rem;
-  border: 1px solid #d7deea;
-  border-radius: 10px;
-  font-size: 0.84rem;
-  outline: none;
-  transition: border-color 0.2s, box-shadow 0.2s;
-  background-color: var(--input-bg);
-  color: #111c2a;
-}
-
-html[data-theme='dark'] .navbar__input {
-  border: 1px solid rgba(96, 143, 203, 0.45);
-  background-color: rgba(15, 31, 52, 0.92);
-  color: #e6eefb;
-}
-
-.navbar__input:focus {
-  border-color: #0055a2;
-  box-shadow: 0 0 0 3px rgba(0, 85, 162, 0.12);
-}
-
-.navbar__input::placeholder {
-  color: #8991a4;
-}
-
-html[data-theme='dark'] .navbar__input::placeholder {
-  color: #86a2c9;
+  flex-shrink: 0;
 }
 
 /* Review surfaces */
@@ -731,17 +681,6 @@ html[data-theme='dark'] .navbar__notification-empty {
   background: rgba(255, 255, 255, 0.12);
 }
 
-.navbar.scrolled .navbar__input {
-  background: rgba(255, 255, 255, 0.14);
-  border-color: rgba(255, 255, 255, 0.22);
-  color: #ffffff;
-}
-
-.navbar.scrolled .navbar__input::placeholder,
-.navbar.scrolled .navbar__search-icon {
-  color: rgba(255, 255, 255, 0.74);
-}
-
 .navbar.scrolled .navbar__auth-btn {
   border-color: rgba(255, 255, 255, 0.22);
   background: rgba(255, 255, 255, 0.1);
@@ -754,10 +693,6 @@ html[data-theme='dark'] .navbar__notification-empty {
 }
 
 @media (max-width: 1180px) {
-  .navbar__search {
-    display: none;
-  }
-
   .navbar__links {
     max-width: calc(100vw - 255px);
   }
@@ -2751,7 +2686,7 @@ html[data-theme='dark'] .homepage-system__arrow {
 
 .roadmap-search-overlay__panel {
   position: relative;
-  width: min(92vw, 1280px);
+  width: min(96vw, 1440px);
   height: min(calc(100vh - 108px), 860px);
   border-radius: 14px;
   overflow: hidden;
@@ -2817,7 +2752,7 @@ html[data-theme='dark'] .homepage-system__arrow {
 }
 
 .roadmap-search-page__left {
-  width: 30%;
+  width: 38%;
   border-right: 1px solid #dbe3ef;
   background: linear-gradient(180deg, #eff4fb 0%, #edf2f7 100%);
   overflow-y: auto;
@@ -2836,8 +2771,314 @@ html[data-theme='dark'] .homepage-system__arrow {
 }
 
 .roadmap-search-page__right {
-  width: 70%;
+  width: 62%;
   background: #f8fafc;
+}
+
+.roadmap-search-page__query {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0;
+  margin: 0 0 14px;
+  scroll-margin-top: 8px;
+}
+
+.roadmap-search-query-bar {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.roadmap-search-query-bar__shell {
+  border-radius: 12px;
+  padding: 4px 2px 8px;
+}
+
+.roadmap-search-query-bar__row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+}
+
+.roadmap-search-query-bar__split {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  width: 100%;
+  gap: 6px;
+}
+
+.roadmap-search-query-bar__hash {
+  flex-shrink: 0;
+  align-self: center;
+  font-size: 1rem;
+  font-weight: 800;
+  color: #64748b;
+  user-select: none;
+}
+
+.roadmap-search-query-bar__tag-zone {
+  flex: 1 1 42%;
+  min-width: min(180px, 36vw);
+  max-width: 55%;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 85, 162, 0.45);
+  background: linear-gradient(180deg, rgba(0, 85, 162, 0.1) 0%, rgba(0, 85, 162, 0.04) 100%);
+  box-shadow: 0 0 0 2px rgba(0, 85, 162, 0.12);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.roadmap-search-query-bar__tag-zone:focus-within {
+  border-color: rgba(0, 85, 162, 0.75);
+  box-shadow:
+    0 0 0 2px rgba(0, 85, 162, 0.16),
+    0 0 0 4px rgba(0, 85, 162, 0.1);
+}
+
+.roadmap-search-query-bar__tag-input {
+  box-sizing: border-box;
+  width: 100%;
+  height: 36px;
+  margin: 0;
+  padding: 0 0.65rem;
+  border: none;
+  border-radius: 9px;
+  font-size: 0.88rem;
+  line-height: 1.35;
+  outline: none;
+  background: transparent;
+  color: #0f172a;
+}
+
+.roadmap-search-query-bar__tag-input::placeholder {
+  color: #64748b;
+  opacity: 0.85;
+}
+
+html[data-theme='dark'] .roadmap-search-query-bar__tag-zone {
+  border-color: rgba(119, 172, 242, 0.55);
+  background: linear-gradient(180deg, rgba(62, 139, 214, 0.22) 0%, rgba(62, 139, 214, 0.06) 100%);
+  box-shadow: 0 0 0 2px rgba(62, 139, 214, 0.15);
+}
+
+html[data-theme='dark'] .roadmap-search-query-bar__tag-zone:focus-within {
+  border-color: rgba(147, 197, 253, 0.85);
+  box-shadow:
+    0 0 0 2px rgba(62, 139, 214, 0.28),
+    0 0 0 4px rgba(62, 139, 214, 0.12);
+}
+
+html[data-theme='dark'] .roadmap-search-query-bar__tag-input {
+  color: #e6eefb;
+}
+
+html[data-theme='dark'] .roadmap-search-query-bar__tag-input::placeholder {
+  color: #86a2c9;
+}
+
+html[data-theme='dark'] .roadmap-search-query-bar__hash {
+  color: #8eb4e8;
+}
+
+.roadmap-search-query-bar__field-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.roadmap-search-query-bar__suggestions {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 4px);
+  z-index: 20;
+  max-height: 220px;
+  overflow-y: auto;
+  border: 1px solid #dbe3ef;
+  border-radius: 10px;
+  background: #ffffff;
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.12);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.roadmap-search-query-bar__suggestion {
+  text-align: left;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 0.84rem;
+  cursor: pointer;
+  background: transparent;
+  color: #0f172a;
+}
+
+.roadmap-search-query-bar__suggestion:hover {
+  background: #eef4fb;
+}
+
+.roadmap-search-query-bar__suggestion--free {
+  color: #0055a2;
+  font-weight: 600;
+}
+
+.roadmap-search-query-bar__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding-left: 28px;
+}
+
+.roadmap-search-query-bar__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px 4px 10px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: #e0ecfb;
+  border: 1px solid #bfdbfe;
+  color: #1e3a5f;
+}
+
+.roadmap-search-query-bar__chip-label {
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.roadmap-search-query-bar__chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 999px;
+  padding: 2px;
+  background: transparent;
+  cursor: pointer;
+  color: inherit;
+  opacity: 0.75;
+}
+
+.roadmap-search-query-bar__chip-remove:hover {
+  opacity: 1;
+  background: rgba(29, 78, 216, 0.12);
+}
+
+.roadmap-search-page__query-icon {
+  flex-shrink: 0;
+  color: #64748b;
+}
+
+html[data-theme='dark'] .roadmap-search-page__query-icon {
+  color: #8eb4e8;
+}
+
+html[data-theme='dark'] .roadmap-search-query-bar__suggestions {
+  border-color: rgba(95, 145, 210, 0.42);
+  background: #132741;
+  box-shadow: 0 18px 36px rgba(2, 9, 20, 0.55);
+}
+
+html[data-theme='dark'] .roadmap-search-query-bar__suggestion {
+  color: #e6eefb;
+}
+
+html[data-theme='dark'] .roadmap-search-query-bar__suggestion:hover {
+  background: rgba(78, 136, 211, 0.22);
+}
+
+html[data-theme='dark'] .roadmap-search-query-bar__suggestion--free {
+  color: #93c5fd;
+}
+
+html[data-theme='dark'] .roadmap-search-query-bar__chip {
+  background: rgba(29, 78, 216, 0.22);
+  border-color: rgba(119, 172, 242, 0.45);
+  color: #dcebfd;
+}
+
+.roadmap-search-results__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 6px 0 4px;
+}
+
+.roadmap-search-results__tag {
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #e8f0fc;
+  border: 1px solid #cbd5e9;
+  color: #334155;
+}
+
+html[data-theme='dark'] .roadmap-search-results__tag {
+  background: rgba(29, 78, 216, 0.2);
+  border-color: rgba(119, 172, 242, 0.35);
+  color: #c8ddfb;
+}
+
+.roadmap-search-page__input {
+  box-sizing: border-box;
+  flex: 1;
+  min-width: 0;
+  height: 36px;
+  padding: 0 0.75rem;
+  border: 1px solid #d7deea;
+  border-radius: 10px;
+  font-size: 0.88rem;
+  line-height: 1.35;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s, background-color 0.2s;
+  background-color: #ffffff;
+  color: #0f172a;
+}
+
+.roadmap-search-page__input--full {
+  display: block;
+  width: 100%;
+}
+
+.roadmap-search-page__input--name-part {
+  flex: 1 1 48%;
+  min-width: 72px;
+}
+
+html[data-theme='dark'] .roadmap-search-page__input {
+  border: 1px solid rgba(96, 143, 203, 0.45);
+  background-color: rgba(15, 31, 52, 0.92);
+  color: #e6eefb;
+}
+
+.roadmap-search-page__input:focus {
+  border-color: #0055a2;
+  box-shadow: 0 0 0 3px rgba(0, 85, 162, 0.12);
+}
+
+html[data-theme='dark'] .roadmap-search-page__input:focus {
+  border-color: #3e8bd6;
+  box-shadow: 0 0 0 3px rgba(62, 139, 214, 0.18);
+}
+
+.roadmap-search-page__input::placeholder {
+  color: #8991a4;
+}
+
+html[data-theme='dark'] .roadmap-search-page__input::placeholder {
+  color: #86a2c9;
 }
 
 .roadmap-search-page__section-header {

--- a/frontend/src/style/general-component.css
+++ b/frontend/src/style/general-component.css
@@ -2925,6 +2925,12 @@ html[data-theme='dark'] .roadmap-search-query-bar__hash {
   background: #eef4fb;
 }
 
+.roadmap-search-query-bar__suggestion--keyboard-active {
+  background: #e2eefb;
+  outline: 2px solid rgba(0, 85, 162, 0.35);
+  outline-offset: -2px;
+}
+
 .roadmap-search-query-bar__suggestion--free {
   color: #0055a2;
   font-weight: 600;
@@ -2996,6 +3002,11 @@ html[data-theme='dark'] .roadmap-search-query-bar__suggestion {
 
 html[data-theme='dark'] .roadmap-search-query-bar__suggestion:hover {
   background: rgba(78, 136, 211, 0.22);
+}
+
+html[data-theme='dark'] .roadmap-search-query-bar__suggestion--keyboard-active {
+  background: rgba(78, 136, 211, 0.28);
+  outline-color: rgba(147, 197, 253, 0.45);
 }
 
 html[data-theme='dark'] .roadmap-search-query-bar__suggestion--free {

--- a/specs/015-roadmap-tags/checklists/requirements.md
+++ b/specs/015-roadmap-tags/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Roadmap Tags
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass based on the current spec draft.
+- Ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/015-roadmap-tags/contracts/roadmap-tags-api.md
+++ b/specs/015-roadmap-tags/contracts/roadmap-tags-api.md
@@ -1,0 +1,104 @@
+# Contract: Roadmap Tags API
+
+## Purpose
+
+Define the request and response shape for roadmap tag editing and tag-filtered roadmap search.
+
+## Endpoints
+
+### Create manual roadmap
+
+`POST /api/roadmaps/manual-roadmaps`
+
+#### Request body
+
+```json
+{
+  "yamlCode": "string",
+  "tags": [
+    { "label": "string" }
+  ]
+}
+```
+
+#### Behavior
+
+- Tags are optional.
+- The server normalizes each tag label before saving.
+- Duplicate tag labels are rejected or deduplicated before persistence, depending on validation mode.
+
+### Update manual roadmap
+
+`PATCH /api/roadmaps/manual-roadmaps/:roadmapId`
+
+#### Request body
+
+```json
+{
+  "yamlCode": "string",
+  "tags": [
+    { "label": "string" }
+  ]
+}
+```
+
+#### Behavior
+
+- Tags replace the saved tag list for the draft roadmap.
+- Existing tags remain visible when the roadmap is reopened.
+
+### List public manual roadmaps
+
+`GET /api/roadmaps/manual-roadmaps/public?q=...&tags=...&page=1&limit=20`
+
+#### Query parameters
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `q` | String | Optional keyword query |
+| `tags` | String or repeated query values | Optional normalized tag filters |
+| `page` | Number | Page number |
+| `limit` | Number | Page size |
+
+#### Behavior
+
+- `q` and `tags` are combined with AND semantics.
+- Multiple `tags` values use OR semantics.
+- Only public/shared roadmaps are returned.
+
+### Get available tags
+
+`GET /api/roadmaps/manual-roadmaps/tags`
+
+#### Behavior
+
+- Returns the distinct tag list derived from public manual roadmaps.
+- The result supports editor tag suggestions and search filter options.
+
+## Response shape
+
+### Manual roadmap summary
+
+```json
+{
+  "_id": "string",
+  "title": "string",
+  "description": "string",
+  "tags": [
+    { "label": "string", "normalizedLabel": "string" }
+  ]
+}
+```
+
+### Public list payload
+
+```json
+{
+  "items": [],
+  "pagination": {
+    "page": 1,
+    "limit": 20,
+    "total": 0
+  }
+}
+```

--- a/specs/015-roadmap-tags/data-model.md
+++ b/specs/015-roadmap-tags/data-model.md
@@ -1,0 +1,78 @@
+# Data Model: Roadmap Tags
+
+## ManualRoadmap
+
+Represents a user-authored roadmap stored in `manual_roadmaps`.
+
+### Fields affected by this feature
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `tags` | Array[RoadmapTag] | no | Canonical tag list attached to the roadmap |
+
+### Validation rules
+
+- Tag labels must be non-empty after trimming.
+- Duplicate tags are not allowed within the same roadmap.
+- Tag labels are stored with a normalized key for comparison and filtering.
+- Existing tag values must survive draft save, edit, and publish flows.
+
+## RoadmapTag
+
+Represents a single tag attached to a roadmap.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `label` | String | yes | Human-readable tag text shown in the editor and search UI |
+| `normalizedLabel` | String | yes | Lowercased trimmed key used for deduplication and filtering |
+
+### Rules
+
+- `normalizedLabel` is derived from `label`.
+- Two tags are considered identical if their `normalizedLabel` values match.
+- A roadmap may contain multiple tags, but each normalized label may appear only once.
+
+## TagFilterSelection
+
+Represents the filter state used by search.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `query` | String | no | Existing keyword query text |
+| `selectedTags` | Array[String] | no | Normalized labels selected by the user |
+| `matchMode` | String | yes | `any` for v1 multi-tag behavior |
+
+### Rules
+
+- `query` and `selectedTags` combine in the same search request.
+- Empty `selectedTags` means no tag filtering is applied.
+- Multiple selected tags use OR matching (`any`).
+
+## SearchableRoadmapSummary
+
+Represents the public roadmap result returned by search.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `_id` | String | yes | Roadmap identifier |
+| `title` | String | yes | Roadmap title |
+| `description` | String | no | Short summary |
+| `tags` | Array[RoadmapTag] | yes | Tags included in the result card and filter matching |
+| `sharedAt` | Date | no | Public sharing timestamp |
+
+## Search request contract
+
+### Manual roadmap public list query
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `q` | String | no | Existing text query |
+| `tags` | String or Array[String] | no | Selected normalized tag labels |
+| `page` | Number | no | Pagination page |
+| `limit` | Number | no | Page size |
+
+### Behavior
+
+- When `tags` is present, the backend filters roadmaps to those that contain at least one selected tag.
+- When both `q` and `tags` are present, both filters apply.
+- Search results remain public/shared-only.

--- a/specs/015-roadmap-tags/plan.md
+++ b/specs/015-roadmap-tags/plan.md
@@ -1,0 +1,124 @@
+# Implementation Plan: Roadmap Tags
+
+**Branch**: `015-roadmap-tags` | **Date**: 2026-05-12 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `d:\Desktop\compass\uetcompass\specs\015-roadmap-tags\spec.md`
+
+## Summary
+
+Add an end-to-end roadmap tagging system to the existing UETCompass web app. The feature has two primary flows: users can create, edit, and remove tags while editing a manual roadmap, and learners can search/filter roadmaps by tags alongside existing search behavior. Tags may be selected from an existing catalog or created in the editor, and the same canonical tag set must power both persistence and discovery.
+
+## Technical Context
+
+**Language/Version**: JavaScript (Node.js backend + React 18 frontend)  
+**Primary Dependencies**: Express 4, Mongoose 8, React 18, Vite 5, Lucide React, existing roadmap modules  
+**Storage**: MongoDB (`manual_roadmaps` for authored/shared roadmaps; tag data stored with roadmap records and indexed for search)  
+**Testing**: Jest 29 for backend unit/integration and frontend behavior tests in repo test setup  
+**Target Platform**: Web app (desktop/laptop primary with responsive fallback)  
+**Project Type**: Web application (frontend + backend monolith)  
+**Performance Goals**: Tag edits should save with the roadmap in one flow; tag-filtered search should remain responsive and avoid stale-result flicker  
+**Constraints**: Public/shared roadmap discovery only, preserve existing auth/navigation behavior, keep monolithic module boundaries, no new services  
+**Scale/Scope**: Single roadmap authoring enhancement plus search/filter extension, with shared tag behavior across edit and discovery flows
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Principle I (Modular Monolithic): PASS. Changes stay inside the existing roadmap backend module and frontend feature/navigation layers.
+- Principle II (UET-First Scope): PASS. Tags are tied to UET roadmap workflows and discovery, not generalized multi-tenant taxonomy.
+- Principle III (Privacy by Minimalism): PASS. No new sensitive student data is introduced; tag data is part of roadmap content.
+- Principle IV (AI-Assisted, Human-Controlled): PASS. Tag creation/editing is user-controlled; no new AI decision logic is required.
+- Principle V (Test What Matters): PASS with action. Add tests for tag CRUD in the editor, duplicate prevention, persistence, and tag-filtered search behavior.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/015-roadmap-tags/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── roadmap-tags-api.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+backend/
+├── src/
+│   └── modules/
+│       └── roadmap/
+│           ├── roadmap.routes.js
+│           ├── roadmap.controller.js
+│           ├── roadmap.service.js
+│           ├── roadmap.model.js
+│           ├── roadmapValidation.service.js
+│           └── [tag editing/search extensions]
+└── tests/
+    ├── integration/
+    └── unit/
+
+frontend/
+├── src/
+│   ├── features/
+│   │   ├── manual-roadmap/
+│   │   │   └── [tag editor UI extensions]
+│   │   └── roadmap-search/
+│   │       └── [tag filter UI extensions]
+│   ├── services/
+│   │   └── roadmap.api.js
+│   └── style/
+│       └── general-component.css
+└── tests/
+```
+
+**Structure Decision**: Extend the existing frontend/backend monolith. Keep tag persistence and validation inside `backend/src/modules/roadmap/`, add manual-roadmap tag editing UI in the existing manual roadmap feature area, and extend the roadmap search feature to accept tag filters without introducing a new service boundary.
+
+## API Bridge Architecture ⚠️ CRITICAL
+
+The tag feature requires explicit API layer coordination between frontend and backend. This section clarifies the execution flow to prevent the 2 critical gaps identified in project analysis:
+
+### Gap A1: Tag Catalog Endpoint
+
+**Problem**: Editors need to choose tags from an existing catalog OR create new ones. Without exposing existing tags, users cannot see what options are available.
+
+**Solution**: Implement a dedicated `GET /manual-roadmaps/tags` endpoint (Phase 2, T011-T012):
+- Backend exposes distinct tags from all public/published roadmaps
+- Frontend loads this catalog on `ManualRoadmapPage` mount (Phase 2, T014)
+- Catalog loaded via `roadmapSearch.api.js` client and stored in component state
+- Editor UI renders tags as selectable chips with existing catalog as suggestions plus free-form creation option
+
+**Where Implemented**:
+- Backend: `backend/src/modules/roadmap/roadmap.controller.js` (route parsing) + `manualRoadmap.service.js` (distinct query)
+- Frontend: `frontend/src/features/manual-roadmap/ManualRoadmapPage.jsx` (mount effect) + `frontend/src/services/roadmapSearch.api.js` (client call)
+
+### Gap A2: Frontend API Payload Wiring
+
+**Problem**: The frontend API client (`manualRoadmap.api.js`) currently only accepts `yamlCode` parameter. Editor can build tag state but cannot send it to backend, breaking persistence.
+
+**Solution**: Update API client functions to accept tags parameter (Phase 2, T013 + Phase 3 early):
+- Modify `createManualRoadmap(authToken, { yamlCode, tags })` signature
+- Modify `updateManualRoadmap(authToken, roadmapId, { yamlCode, tags })` signature
+- Wire editor's tag state into these calls when saving (Phase 3, T018 context)
+
+**Where Implemented**:
+- Frontend API: `frontend/src/services/manualRoadmap.api.js` (client functions)
+- Frontend UI: `frontend/src/features/manual-roadmap/ManualRoadmapPage.jsx` (tag state + save handler wiring)
+- Backend: Already ready via T004-T007 (model, validation, serialization)
+
+**Impact**: Without both fixes, the feature cannot ship:
+- Without A1 (catalog): Users cannot discover existing tags → cannot select from catalog per FR-006
+- Without A2 (API bridge): Tag state from UI never reaches database → tags not persisted per FR-004
+
+---
+
+## Complexity Tracking
+
+No constitution violations requiring justification.
+
+**Critical Gaps Fixed in Phase 2**:
+- ✅ Gap A1: Tag catalog endpoint (GET /manual-roadmaps/tags) + frontend loader
+- ✅ Gap A2: API client payload wiring (tags parameter in create/update functions)

--- a/specs/015-roadmap-tags/quickstart.md
+++ b/specs/015-roadmap-tags/quickstart.md
@@ -1,0 +1,30 @@
+# Quickstart: Roadmap Tags
+
+## Local setup
+
+1. Start the backend and frontend the same way as the existing UETCompass web app.
+2. Open the manual roadmap editor and confirm an existing draft can be loaded.
+3. Open the roadmap search page and confirm public manual roadmaps can still be listed.
+
+## Manual roadmap tagging flow
+
+1. Open a manual roadmap draft.
+2. Add an existing tag or create a new tag inline.
+3. Remove a tag and confirm it disappears from the editor state.
+4. Save the roadmap.
+5. Reopen it and confirm the saved tag list is preserved.
+
+## Search and filter flow
+
+1. Open the roadmap search page.
+2. Type a keyword query and confirm results appear.
+3. Add one or more tag filters.
+4. Confirm the result list narrows without resetting the keyword query.
+5. Clear the tag filters and confirm the broader result list returns.
+
+## Manual verification checklist
+
+- Tag chips render in the editor.
+- Duplicate tags are blocked.
+- Newly created tags are available for later search filtering.
+- Search results respond to tag filters and show an empty state when nothing matches.

--- a/specs/015-roadmap-tags/research.md
+++ b/specs/015-roadmap-tags/research.md
@@ -1,0 +1,36 @@
+# Research: Roadmap Tags
+
+## Decision 1: Store tags as embedded roadmap metadata
+- Decision: Keep tags as an embedded array on each manual roadmap document instead of introducing a separate tag service or microservice.
+- Rationale: Tags are authored inside the roadmap editor, reused for roadmap discovery, and need to stay in sync with the roadmap content. Embedding keeps persistence simple, preserves monolith boundaries, and avoids an extra dependency for a feature that is scoped to a single domain.
+- Alternatives considered:
+  - Separate tag collection with references from roadmaps: rejected because it adds extra writes and sync complexity for a feature that only needs roadmap-scoped tags in v1.
+  - Free-text-only tags without normalization: rejected because search/filter options need stable values and duplicate prevention.
+
+## Decision 2: Support both existing tag selection and new tag creation in the editor
+- Decision: The manual roadmap editor will allow users to pick from existing tags or create a new tag inline.
+- Rationale: This matches the clarified requirement and supports both authoring convenience and discoverability without forcing users into a separate taxonomy-management screen.
+- Alternatives considered:
+  - Existing-tags-only: rejected because the feature must allow creating tags directly in the editor.
+  - Separate tag administration page: rejected because it adds a second workflow not requested by the user.
+
+## Decision 3: Search uses tag filters over the manual roadmap collection
+- Decision: Extend the manual roadmap search endpoint to accept tag filters and combine them with the existing keyword query.
+- Rationale: The current public roadmap discovery flow already queries `manual_roadmaps`, so extending that path keeps the implementation cohesive and lets one dataset power both editor and search flows.
+- Alternatives considered:
+  - Build a new search service: rejected because the roadmap module already owns public manual roadmap discovery.
+  - Search across multiple roadmap collections: rejected because the feature is limited to manual roadmaps and shared roadmap content.
+
+## Decision 4: Multiple selected tags use OR matching
+- Decision: When a user selects more than one tag, results should include roadmaps that match at least one selected tag.
+- Rationale: This is the least surprising discovery behavior for a browse/filter experience and aligns with the clarified specification.
+- Alternatives considered:
+  - AND-only matching: rejected because it would make multi-tag filtering too restrictive for early catalog sizes.
+  - Mixed OR/AND modes: rejected for v1 due to unnecessary UI complexity.
+
+## Decision 5: Canonical tag shape is label + normalized key
+- Decision: Store each tag with a display label and a normalized key derived from the label.
+- Rationale: This gives the editor a friendly display value while search and duplicate detection can rely on a stable normalized form.
+- Alternatives considered:
+  - Database-generated tag IDs: rejected because the feature does not need a separate tag registry in v1.
+  - Raw strings only: rejected because normalization is needed for deduplication and consistent filtering.

--- a/specs/015-roadmap-tags/spec.md
+++ b/specs/015-roadmap-tags/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: Roadmap Tags
+
+**Feature Branch**: `015-roadmap-tags`  
+**Created**: 2026-05-12  
+**Status**: Draft  
+**Input**: User description: "tôi muốn thêm 1 hệ thống tags cho roadmap gồm 2 luồn chính là thêm sửa xáo tags bên trong sửa manual-roadmap page và dùng tags để search lọc kết quả"
+
+## Clarifications
+
+### Session 2026-05-12
+
+- Q: Trong manual-roadmap page, tags có được tạo mới tự do hay chỉ chọn từ danh mục có sẵn? → A: Kết hợp: chọn từ danh mục và có thể tạo tag mới
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Manage Tags While Editing a Roadmap (Priority: P1)
+
+As a roadmap editor, I want to add, replace, and remove tags while editing a manual roadmap so that the roadmap can be categorized before it is published or saved.
+
+**Why this priority**: Tag management is the source of truth for the rest of the feature. If users cannot maintain roadmap tags during editing, search filtering has no reliable data to use.
+
+**Independent Test**: Create or open a manual roadmap, change its tags, save it, reopen it, and verify the updated tag list is preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** a manual roadmap editor with a saved roadmap, **When** the user adds one or more valid tags and saves, **Then** the roadmap retains those tags after reload.
+2. **Given** a manual roadmap editor with existing tags, **When** the user removes or replaces a tag and saves, **Then** the roadmap reflects only the updated tags.
+3. **Given** a manual roadmap editor and a tag name that does not already exist, **When** the user creates the new tag and saves the roadmap, **Then** the new tag is attached to the roadmap and becomes available for later search filtering.
+
+---
+
+### User Story 2 - Filter Search Results by Tags (Priority: P2)
+
+As a learner browsing roadmaps, I want to search and filter results by tags so that I can quickly narrow the roadmap list to topics I care about.
+
+**Why this priority**: Tag-based filtering is the main discovery benefit of the new system and is the primary way users will consume the tag data.
+
+**Independent Test**: Open the roadmap search experience, apply one or more tag filters, and verify that the result set changes to match the selected tags.
+
+**Acceptance Scenarios**:
+
+1. **Given** a search page with available tags, **When** the user selects a tag filter, **Then** the visible results are limited to roadmaps that match that tag.
+2. **Given** multiple tag filters are available, **When** the user selects more than one tag, **Then** the results include roadmaps that match at least one of the selected tags.
+
+---
+
+### User Story 3 - Combine Tags With Existing Search Behavior (Priority: P3)
+
+As a learner, I want tag filters to work together with existing search criteria so that I can refine results without losing the rest of my search intent.
+
+**Why this priority**: This keeps the feature useful in real browsing flows and prevents tags from becoming an isolated filter that users must start over to use.
+
+**Independent Test**: Apply a keyword search and tag filters together, then clear or change the tags and verify that the rest of the search still behaves consistently.
+
+**Acceptance Scenarios**:
+
+1. **Given** a keyword search and one or more tag filters, **When** the user updates the tag selection, **Then** the result list updates without resetting unrelated search criteria.
+2. **Given** a tag-filtered search with no matching roadmaps, **When** the user clears the tag filter, **Then** broader results become available again if matching roadmaps exist.
+
+---
+
+### Edge Cases
+
+- Adding the same tag more than once must not create duplicate entries.
+- Removing the last remaining tag must leave the roadmap in a valid saved state.
+- If a user searches with tags that match nothing, the interface must show a clear empty state.
+- If a roadmap already has tags and the user opens it for editing, the existing tags must be visible and editable.
+- If a tag is unavailable in the current catalog, existing roadmaps must still render their stored tag labels clearly enough for users to remove or replace them.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST allow users to add tags to a roadmap while editing it in the manual roadmap flow.
+- **FR-002**: The system MUST allow users to remove existing tags from a roadmap before saving.
+- **FR-003**: The system MUST allow users to replace one roadmap tag with another without losing the rest of the roadmap content.
+- **FR-004**: The system MUST preserve a roadmap's saved tags when the roadmap is reopened for viewing or editing.
+- **FR-005**: The system MUST prevent duplicate tags from being assigned to the same roadmap.
+- **FR-006**: The system MUST allow users to create new tags while editing a roadmap.
+- **FR-007**: The system MUST use the same tag set for roadmap editing and roadmap search filtering.
+- **FR-008**: The system MUST allow users to filter roadmap search results by one or more selected tags.
+- **FR-009**: The system MUST keep tag filtering compatible with existing roadmap search criteria so users can refine results without starting over.
+- **FR-010**: The system MUST show a clear empty state when no roadmap matches the selected tag filters.
+- **FR-011**: The system MUST display existing tags on a roadmap in a way that allows users to understand, remove, or replace them during editing.
+
+### Key Entities *(include if feature involves data)*
+
+- **Roadmap Tag**: A tag attached to a roadmap, identified by its canonical label and used for categorization and search filtering.
+- **Tag Catalog Entry**: A tag definition that can already exist or be created in the manual roadmap editor and then reused for search filtering.
+- **Roadmap Tag Assignment**: The association between a roadmap and the tags currently attached to it, including the saved tag list shown during editing and search indexing.
+- **Tag Filter Selection**: The set of one or more tags a learner chooses to narrow roadmap search results.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: At least 95% of users can add, remove, or replace roadmap tags and save the roadmap successfully within 2 minutes.
+- **SC-002**: At least 95% of saved roadmaps reopen with the same tag list that was last saved.
+- **SC-003**: At least 90% of tag-filtered roadmap searches return visible results or a clear no-results state within 3 seconds under normal usage.
+- **SC-004**: At least 90% of first-time users can narrow roadmap results with tags without assistance.
+
+## Assumptions
+
+- Tags can be selected from an existing catalog or created in the manual roadmap editor.
+- Tags are attached to roadmaps, not to individual roadmap steps.
+- Tag changes are saved together with the roadmap content in the same editing flow.
+- Tag filtering applies to roadmap discovery and search results, not to unrelated app areas.
+- Existing keyword search behavior remains available alongside tag filters.
+- When multiple tags are selected, search results must include roadmaps that match at least one selected tag.

--- a/specs/015-roadmap-tags/tasks.md
+++ b/specs/015-roadmap-tags/tasks.md
@@ -1,0 +1,277 @@
+# Tasks: Roadmap Tags
+
+**Input**: Design documents from `/specs/015-roadmap-tags/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Included because the feature plan requires validation of tag CRUD, persistence, and tag-filtered search behavior.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and tested independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and shared tagging foundations
+
+- [ ] T001 Update roadmap feature context in `specs/015-roadmap-tags/research.md`, `specs/015-roadmap-tags/data-model.md`, and `specs/015-roadmap-tags/contracts/roadmap-tags-api.md`
+- [ ] T002 [P] Add roadmap tag contract examples and response shapes to `specs/015-roadmap-tags/contracts/roadmap-tags-api.md`
+- [ ] T003 [P] Update roadmap tagging quickstart scenarios in `specs/015-roadmap-tags/quickstart.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core data shape and shared backend/frontend primitives required before any story work
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T004 Add tag fields to `backend/src/modules/roadmap/manualRoadmap.model.js` for embedded roadmap tags
+- [ ] T005 [P] Extend roadmap tag normalization and validation in `backend/src/modules/roadmap/manualRoadmapValidation.service.js`
+- [ ] T006 [P] Add shared tag serialization helpers in `backend/src/modules/roadmap/manualRoadmap.service.js`
+- [ ] T007 Add public manual roadmap tag projection support in `backend/src/modules/roadmap/manualRoadmap.service.js`
+- [ ] T008 Extend public roadmap search request parsing in `backend/src/modules/roadmap/roadmap.controller.js`
+- [ ] T009 [P] Extend roadmap search API client contract in `frontend/src/services/roadmapSearch.api.js`
+- [ ] T010 [P] Prepare shared tag state helpers for roadmap UI in `frontend/src/features/manual-roadmap/ManualRoadmapPage.jsx`
+
+**⚠️ CRITICAL API BRIDGE TASKS** (Fix HIGH coverage gaps A1 & A2):
+
+- [ ] T011 Implement `GET /manual-roadmaps/tags` endpoint in `backend/src/modules/roadmap/roadmap.controller.js` to fetch distinct tags from public roadmaps (Gap A1)
+- [ ] T012 [P] Implement distinct tag query logic in `backend/src/modules/roadmap/manualRoadmap.service.js` to support tag catalog endpoint (Gap A1)
+- [ ] T013 [P] Update `frontend/src/services/manualRoadmap.api.js` to accept tags parameter in `createManualRoadmap()` and `updateManualRoadmap()` functions (Gap A2)
+- [ ] T014 [P] Load tag catalog in `frontend/src/features/manual-roadmap/ManualRoadmapPage.jsx` on mount via `GET /manual-roadmaps/tags` and wire tag state to API calls (Gaps A1+A2)
+
+**Checkpoint**: Foundation AND API bridge ready - user story implementation can now begin in parallel
+
+---
+
+## Phase 3: User Story 1 - Manage Tags While Editing a Roadmap (Priority: P1) 🎯 MVP
+
+**Goal**: Users can add, edit, remove, and create tags while working inside the manual roadmap editor, and those tags persist when the roadmap is saved and reopened.
+
+**Independent Test**: Open a manual roadmap draft, add a tag, remove it, create a new tag, save, and verify the saved roadmap reloads with the updated tag list intact.
+
+### Tests for User Story 1
+
+- [ ] T015 [P] [US1] Add backend validation tests for roadmap tag persistence and duplicate prevention in `backend/tests/unit/manualRoadmapValidation.service.test.js`
+- [ ] T016 [P] [US1] Add backend service tests for create/update tag persistence in `backend/tests/unit/manualRoadmap.service.test.js`
+- [ ] T017 [P] [US1] Add frontend editor behavior tests for add/remove/create tag interactions in `frontend/src/features/manual-roadmap/ManualRoadmapPage.test.jsx`
+
+### Implementation for User Story 1
+
+- [ ] T018 [P] [US1] Extend roadmap tag data model and persistence in `backend/src/modules/roadmap/manualRoadmap.model.js`
+- [ ] T019 [US1] Implement tag normalization, deduplication, and inline creation rules in `backend/src/modules/roadmap/manualRoadmapValidation.service.js`
+- [ ] T020 [US1] Persist roadmap tags on create/update flows in `backend/src/modules/roadmap/manualRoadmap.service.js`
+- [ ] T021 [P] [US1] Load and project roadmap tags into the editor state in `frontend/src/features/manual-roadmap/ManualRoadmapPage.jsx`
+- [ ] T022 [US1] Build tag chip add/remove/create UI in `frontend/src/features/manual-roadmap/ManualRoadmapPage.jsx`
+- [ ] T023 [US1] Render saved tags when reopening an existing roadmap in `frontend/src/features/manual-roadmap/ManualRoadmapPage.jsx`
+
+**Checkpoint**: User Story 1 should be fully functional and testable independently
+
+---
+
+## Phase 4: User Story 2 - Filter Search Results by Tags (Priority: P2)
+
+**Goal**: Users can search public roadmaps with tag filters and get results narrowed to matching roadmaps.
+
+**Independent Test**: Open roadmap search, select one or more tags, and verify the results list contains only matching roadmaps.
+
+### Tests for User Story 2
+
+- [ ] T024 [P] [US2] Add backend API tests for tag-filtered public search in `backend/tests/integration/manualRoadmapSearch.api.test.js`
+- [ ] T025 [P] [US2] Add frontend search hook tests for tag-filtered requests in `frontend/src/features/roadmap-search/useRoadmapSearch.test.js`
+- [ ] T026 [P] [US2] Add frontend search UI tests for tag filter selection in `frontend/src/features/roadmap-search/RoadmapSearchPage.test.jsx`
+
+### Implementation for User Story 2
+
+- [ ] T027 [P] [US2] Add tag filter query parsing and validation in `backend/src/modules/roadmap/roadmap.controller.js`
+- [ ] T028 [US2] Implement tag-aware public manual roadmap search in `backend/src/modules/roadmap/manualRoadmap.service.js`
+- [ ] T029 [P] [US2] Extend the search API client to send tag filters from `frontend/src/services/roadmapSearch.api.js`
+- [ ] T030 [US2] Add tag filter UI state and query synchronization in `frontend/src/features/roadmap-search/useRoadmapSearch.js`
+- [ ] T031 [US2] Render selectable tag filters in `frontend/src/features/roadmap-search/RoadmapSearchPage.jsx`
+- [ ] T032 [US2] Show filtered result summaries and empty-state messaging in `frontend/src/features/roadmap-search/RoadmapSearchResults.jsx`
+
+**Checkpoint**: User Story 2 should be fully functional and testable independently
+
+---
+
+## Phase 5: User Story 3 - Combine Tags With Existing Search Behavior (Priority: P3)
+
+**Goal**: Tag filters work alongside the existing keyword search flow without resetting the user's current search intent.
+
+**Independent Test**: Type a keyword search, add or remove tag filters, and confirm the keyword query stays active while results update.
+
+### Tests for User Story 3
+
+- [ ] T033 [P] [US3] Add backend integration coverage for combined keyword and tag filters in `backend/tests/integration/manualRoadmapSearch.api.test.js`
+- [ ] T034 [P] [US3] Add frontend debounce and query-preservation tests in `frontend/src/features/roadmap-search/useRoadmapSearch.test.js`
+- [ ] T035 [P] [US3] Add UI regression tests for combined keyword + tag search in `frontend/src/features/roadmap-search/RoadmapSearchPage.test.jsx`
+
+### Implementation for User Story 3
+
+- [ ] T036 [US3] Preserve keyword search state while applying tag filters in `frontend/src/features/roadmap-search/useRoadmapSearch.js`
+- [ ] T037 [P] [US3] Keep the combined keyword/tag request contract stable in `backend/src/modules/roadmap/roadmap.controller.js`
+- [ ] T038 [US3] Update result rendering and empty states to reflect combined filters in `frontend/src/features/roadmap-search/RoadmapSearchPage.jsx`
+- [ ] T039 [US3] Ensure multi-tag selection uses OR matching in `backend/src/modules/roadmap/manualRoadmap.service.js`
+
+**Checkpoint**: User Stories 1, 2, and 3 should all work independently
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [ ] T040 [P] Sync roadmap tags into shared UI styles in `frontend/src/style/general-component.css`
+- [ ] T041 [P] Update manual roadmap and search documentation references in `README.md` and `specs/015-roadmap-tags/quickstart.md`
+- [ ] T042 Clean up roadmap tag helper code and remove temporary scaffolding in `backend/src/modules/roadmap/` and `frontend/src/features/roadmap-search/`
+- [ ] T043 Validate tag search and edit flows against `specs/015-roadmap-tags/quickstart.md`
+- [ ] T044 Run full lint/test sweep for touched backend and frontend roadmap files
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+  - **API Bridge Checkpoint** (T011-T014): CRITICAL MUST-COMPLETE before any user story
+    - These tasks fix the 2 HIGH severity coverage gaps (A1: tag catalog endpoint, A2: API payload wiring)
+    - Without T011-T014, even completed user stories cannot ship (tags won't load or persist)
+- **User Stories (Phase 3+)**: All depend on Foundational phase completion (including API bridge tasks T011-T014)
+  - User stories can then proceed in parallel (if staffed)
+  - Or sequentially in priority order (P1 → P2 → P3)
+- **Polish (Final Phase)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational + API Bridge (Phase 2 with T011-T014) - No dependencies on other stories
+- **User Story 2 (P2)**: Can start after Foundational + API Bridge (Phase 2 with T011-T014) - Uses the same tag data shape but remains independently testable
+- **User Story 3 (P3)**: Can start after Foundational + API Bridge (Phase 2 with T011-T014) - Builds on the existing search flow but remains independently testable
+
+### Within Each User Story
+
+- Tests (if included) MUST be written and FAIL before implementation
+- Models before services
+- Services before endpoints/UI wiring
+- **For User Story 1 with API bridge**: T014 (Load tag catalog) must complete before T022 (Build tag chip UI) so tags can be displayed as suggestions
+- Core implementation before integration
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- Setup tasks marked [P] can run in parallel
+- Foundational tasks marked [P] can run in parallel within Phase 2
+  - **⚠️ Exception**: T011-T014 (API bridge) must complete before any user story work starts
+  - But within T011-T014: T012, T013, T014 can run in parallel since they touch separate layers
+- User Story 1 test tasks marked [P] can run in parallel (T015-T017)
+- User Story 1 implementation tasks touching separate files can run in parallel (T018-T023)
+- User Story 2 test tasks marked [P] can run in parallel (T024-T026)
+- User Story 3 test tasks marked [P] can run in parallel (T033-T035)
+
+---
+
+## Parallel Example: Foundational Phase + User Story 1
+
+```bash
+# API Bridge tasks can partially parallelize:
+Task: "T012: Implement distinct tag query in manualRoadmap.service.js" (backend layer)
+Task: "T013: Update manualRoadmap.api.js to accept tags" (frontend API layer)
+Task: "T014: Load tag catalog in ManualRoadmapPage" (frontend UI layer)
+# Run together, but all must finish before user story work begins
+
+# Then User Story 1 editor and persistence tests together:
+Task: "T015: Add backend validation tests for roadmap tag persistence" (backend tests)
+Task: "T016: Add backend service tests for create/update tag persistence" (backend tests)
+Task: "T017: Add frontend editor behavior tests for add/remove/create tag interactions" (frontend tests)
+
+# Then User Story 1 implementation work on separate files together:
+Task: "T018: Extend roadmap tag data model and persistence" (backend model)
+Task: "T021: Load and project roadmap tags into the editor state" (frontend state)
+
+# UI implementation can start after:
+Task: "T022: Build tag chip add/remove/create UI" (frontend UI)
+Task: "T023: Render saved tags when reopening an existing roadmap" (frontend UI)
+```
+
+---
+
+## Implementation Strategy
+
+### ⚠️ CRITICAL: API Bridge Checkpoint (T011-T014)
+
+Before starting ANY user story, complete all Phase 2 tasks including the API bridge tasks (T011-T014):
+- **T011-T012**: Implement `GET /manual-roadmaps/tags` endpoint (backend)
+- **T013**: Update API client to accept tags in payloads (frontend API)
+- **T014**: Load and wire tag catalog in editor (frontend UI)
+
+**Why Critical**: 
+- Without T011-T012: Tag catalog never exposed → users cannot select from existing tags (FR-006, FR-007 broken)
+- Without T013-T014: Tag state from editor never reaches backend → tags not persisted (FR-004 broken, FR-001-003 incomplete)
+- These gaps were identified as HIGH severity in project analysis; skipping them causes entire feature to fail at runtime
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational + API Bridge (T004-T014) ⚠️ CRITICAL
+3. Complete Phase 3: User Story 1 (T015-T023)
+4. **STOP and VALIDATE**: Test User Story 1 independently using quickstart.md scenarios
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational + API Bridge → Foundation + bridge ready
+2. Add User Story 1 → Test independently → Deploy/Demo (MVP)
+3. Add User Story 2 → Test independently → Deploy/Demo
+4. Add User Story 3 → Test independently → Deploy/Demo
+5. Each story adds value without breaking previous stories
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. **API Bridge Gate**: T011-T014 must complete before user story teams start
+3. Once API Bridge is verified:
+   - Developer A: User Story 1 (T015-T023)
+   - Developer B: User Story 2 (T024-T032)
+   - Developer C: User Story 3 (T033-T039)
+4. Stories complete and integrate independently
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies within the same phase layer
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Verify tests fail before implementing
+
+### Critical API Bridge (T011-T014) Notes
+
+These 4 tasks fix the 2 HIGH severity coverage gaps identified during project analysis:
+
+- **Gap A1 (Tag Catalog)**: Fixed by T011-T012 + T014
+  - Without: Editor has no way to show existing tags → FR-006 (allow selection from catalog) broken
+  - T011: Add `GET /manual-roadmaps/tags` route to roadmap.controller.js
+  - T012: Implement distinct tag query in manualRoadmap.service.js
+  - T014: Load catalog in ManualRoadmapPage and pass to tag UI component
+
+- **Gap A2 (API Payload Wiring)**: Fixed by T013 + T014
+  - Without: Tag state from editor component never sent to backend → FR-001-004 (persist tags) broken
+  - T013: Update manualRoadmap.api.js to accept `tags` in createManualRoadmap() and updateManualRoadmap() payloads
+  - T014: Wire editor's tag state into these API calls when saving
+
+- Both gaps must be fixed before feature ships; together they form the critical API bridge between frontend UI layer and backend persistence layer
+
+### Execution Guidelines
+
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Avoid: vague tasks, same file conflicts, cross-story dependencies that break independence
+- Test failures before implementations per TDD approach
+- Use quickstart.md scenarios for validation at each checkpoint


### PR DESCRIPTION
closes #186 
PR này tập trung vào việc cải thiện khả năng lọc dữ liệu thông qua hệ thống tags và tối ưu hóa luồng tìm kiếm từ Navbar đến Search Page.

Changes Made
UI/UX:

Cập nhật Navbar.jsx: Thay thế search input bằng SearchIcon.

Cập nhật SearchPage.jsx: Thêm thanh search trung tâm với kích thước chiều ngang lớn hơn.

Thêm logic highlight đặc biệt cho chuỗi ký tự bắt đầu bằng # trong input.

Logic & Features:

Triển khai bộ lọc tag trong API/Frontend logic cho Roadmap.

Xây dựng component TagChip có nút xóa (x).

Xử lý sự kiện onKeyDown:

Trigger tag mode khi gõ #.

Điều hướng danh sách kết quả bằng phím mũi tên.

Data Handling:

Cập nhật schema/interface của Manual Roadmap để bao gồm mảng tags.

How to Test
Truy cập vào trang web, click vào icon Search trên Navbar.

Kiểm tra xem có được điều hướng đến Search Page và thanh search đã được focus chưa.

Gõ nội dung bất kỳ kèm dấu # (ví dụ: React #frontend).

Dùng phím mũi tên để di chuyển xuống danh sách gợi ý và nhấn Enter.

Xác nhận tag hiển thị bên dưới thanh search và có thể xóa bằng nút x