### PR TITLE
fix(auth): force IPv4 for SMTP transporter to resolve ENETUNREACH error

### DIFF
--- a/backend/src/modules/auth/auth.email.js
+++ b/backend/src/modules/auth/auth.email.js
@@ -7,9 +7,12 @@ function buildTransporter() {
   if (!user || !pass) {
     return null;
   }
-
+  
   return nodemailer.createTransport({
-    service: 'gmail',
+    host: 'smtp.gmail.com',
+    port: 465,
+    secure: true,
+    family: 4,
     auth: { user, pass },
   });
 }


### PR DESCRIPTION
Ép smtp sử dụng Ipv4 có thể sửa lỗi không gửi được otp trên Production